### PR TITLE
Add in toolkit to calculate downsampling ratios

### DIFF
--- a/app/lambdas/calculate_downsampling_ratios_py/calculate_downsampling_ratios.py
+++ b/app/lambdas/calculate_downsampling_ratios_py/calculate_downsampling_ratios.py
@@ -14,9 +14,10 @@ Ensure that
 (tumorCoverageEst * (1 - tumorDupFracEst)) /
 (normalCoverageEst * (1 - normalDupFracEst))
 
-is less than 3
+stays between 1 and 3 inclusive.
 
-If ratio is less than 3 we need to add in a downsampler.
+If the ratio is greater than 3 or less than 1, we need to add in a
+downsampler.
 """
 from typing import Optional, Dict, Union
 

--- a/app/lambdas/calculate_downsampling_ratios_py/calculate_downsampling_ratios.py
+++ b/app/lambdas/calculate_downsampling_ratios_py/calculate_downsampling_ratios.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+"""
+Calculate downsampling ratios
+
+Inputs are
+
+* normalCoverageEst
+* normalDupFracEst
+* tumorCoverageEst
+* tumorDupFracEst
+
+Ensure that
+(tumorCoverageEst * (1 - tumorDupFracEst)) /
+(normalCoverageEst * (1 - normalDupFracEst))
+
+is less than 3
+
+If ratio is less than 3 we need to add in a downsampler.
+"""
+from typing import Optional, Dict, Union
+
+MAX_RATIO = 3
+MIN_RATIO = 1
+
+
+def handler(event, context) -> Optional[Dict[str, Union[float, bool]]]:
+    """
+    Run lambda handler
+    """
+    # Get inputs
+    normal_coverage_estimate = event["normalCoverageEst"]
+    tumor_coverage_estimate = event["tumorCoverageEst"]
+    normal_dup_frac_estimate = event["normalDupFracEst"]
+    tumor_dup_frac_estimate = event["tumorDupFracEst"]
+
+    # Calculate the ratio
+    ratio = (
+            (
+                tumor_coverage_estimate * (1 - tumor_dup_frac_estimate)
+            ) /
+            (
+                normal_coverage_estimate * (1 - normal_dup_frac_estimate)
+            )
+    )
+
+    # If the ratio is greater than 3
+    # Then we subsample the tumor down to 3
+    if ratio > MAX_RATIO:
+        return {
+            "enableFractionalDownSampler": True,
+            "downSamplerTumorSubsample": round(MAX_RATIO / ratio, 2)
+        }
+    elif ratio < MIN_RATIO:
+        return {
+            "enableFractionalDownSampler": True,
+            "downSamplerNormalSubsample": round(ratio / MIN_RATIO, 2)
+        }
+
+    # Otherwise return none
+    return None

--- a/app/lambdas/calculate_downsampling_ratios_py/calculate_downsampling_ratios.py
+++ b/app/lambdas/calculate_downsampling_ratios_py/calculate_downsampling_ratios.py
@@ -16,13 +16,49 @@ Ensure that
 
 stays between 1 and 3 inclusive.
 
-If the ratio is greater than 3 or less than 1, we need to add in a
-downsampler.
+If the ratio is greater than 3 we subsample the tumor down to 3,
+if the ratio is less than 1 we subsample the normal down to the tumor level.
 """
 from typing import Optional, Dict, Union
 
 MAX_RATIO = 3
 MIN_RATIO = 1
+
+
+def _validate_inputs(
+    normal_coverage_estimate: float,
+    tumor_coverage_estimate: float,
+    normal_dup_frac_estimate: float,
+    tumor_dup_frac_estimate: float,
+) -> None:
+    """
+    Validate that coverage estimates and duplication fractions are within
+    acceptable ranges before computing the tumor/normal ratio.
+
+    Raises ValueError if any value is out of range.
+    """
+    # Coverage estimates must be positive (negative values such as -1 indicate
+    # that QC stats were unavailable)
+    if normal_coverage_estimate <= 0:
+        raise ValueError(
+            f"normalCoverageEst must be > 0, got {normal_coverage_estimate}"
+        )
+    if tumor_coverage_estimate <= 0:
+        raise ValueError(
+            f"tumorCoverageEst must be > 0, got {tumor_coverage_estimate}"
+        )
+
+    # Duplication fractions must be in [0, 1).  A value of 1 would make the
+    # effective coverage zero and cause a ZeroDivisionError; negative values
+    # are nonsensical.
+    if not (0 <= normal_dup_frac_estimate < 1):
+        raise ValueError(
+            f"normalDupFracEst must be in [0, 1), got {normal_dup_frac_estimate}"
+        )
+    if not (0 <= tumor_dup_frac_estimate < 1):
+        raise ValueError(
+            f"tumorDupFracEst must be in [0, 1), got {tumor_dup_frac_estimate}"
+        )
 
 
 def handler(event, context) -> Optional[Dict[str, Union[float, bool]]]:
@@ -35,7 +71,15 @@ def handler(event, context) -> Optional[Dict[str, Union[float, bool]]]:
     normal_dup_frac_estimate = event["normalDupFracEst"]
     tumor_dup_frac_estimate = event["tumorDupFracEst"]
 
-    # Calculate the ratio
+    # Validate inputs before computing the ratio
+    _validate_inputs(
+        normal_coverage_estimate,
+        tumor_coverage_estimate,
+        normal_dup_frac_estimate,
+        tumor_dup_frac_estimate,
+    )
+
+    # Calculate the effective coverage ratio (tumor / normal)
     ratio = (
             (
                 tumor_coverage_estimate * (1 - tumor_dup_frac_estimate)

--- a/app/lambdas/post_schema_validation_py/post_schema_validation.py
+++ b/app/lambdas/post_schema_validation_py/post_schema_validation.py
@@ -200,11 +200,11 @@ def handler(event, context) -> Dict[str, bool]:
     # Ensure that we comment if downsampling has been added
     if payload_data.get("inputs", {}).get("alignmentOptions", {}).get("enableFractionalDownSampler"):
         comment = "Downsampling has been turned on for this workflow run"
-        if payload_data.get("inputs", {}).get("alignmentOptions", {}).get("downSamplerTumorSubsample"):
+        if payload_data.get("inputs", {}).get("alignmentOptions", {}).get("downSamplerTumorSubsample") is not None:
             comment += ' - tumor has been downsampled to {}'.format(
                 payload_data.get("inputs", {}).get("alignmentOptions", {}).get("downSamplerTumorSubsample")
             )
-        if payload_data.get("inputs", {}).get("alignmentOptions", {}).get("downSamplerNormalSubsample"):
+        if payload_data.get("inputs", {}).get("alignmentOptions", {}).get("downSamplerNormalSubsample") is not None:
             comment += ' - normal has been downsampled to {}'.format(
                 payload_data.get("inputs", {}).get("alignmentOptions", {}).get("downSamplerNormalSubsample")
             )

--- a/app/lambdas/post_schema_validation_py/post_schema_validation.py
+++ b/app/lambdas/post_schema_validation_py/post_schema_validation.py
@@ -197,6 +197,25 @@ def handler(event, context) -> Dict[str, bool]:
             "isValid": False
         }
 
+    # Ensure that we comment if downsampling has been added
+    if payload_data.get("inputs", {}).get("alignmentOptions", {}).get("enableFractionalDownSampler"):
+        comment = "Downsampling has been turned on for this workflow run"
+        if payload_data.get("inputs", {}).get("alignmentOptions", {}).get("downSamplerTumorSubsample"):
+            comment += ' - tumor has been downsampled to {}'.format(
+                payload_data.get("inputs", {}).get("alignmentOptions", {}).get("downSamplerTumorSubsample")
+            )
+        if payload_data.get("inputs", {}).get("alignmentOptions", {}).get("downSamplerNormalSubsample"):
+            comment += ' - normal has been downsampled to {}'.format(
+                payload_data.get("inputs", {}).get("alignmentOptions", {}).get("downSamplerNormalSubsample")
+            )
+        add_comment_to_workflow_run(
+            workflow_run_orcabus_id=workflow_run_id,
+            comment=comment,
+            author=COMMENT_AUTHOR.format(
+                WORKFLOW_NAME=environ.get(WORKFLOW_NAME_ENV_VAR)
+            )
+        )
+
     return {
         "isValid": True
     }

--- a/app/step-functions-templates/populate_draft_data_sfn_template.asl.json
+++ b/app/step-functions-templates/populate_draft_data_sfn_template.asl.json
@@ -1308,10 +1308,10 @@
               "Arguments": {
                 "FunctionName": "${__calculate_downsampling_ratios_lambda_function_arn__}",
                 "Payload": {
-                  "normalCoverageEst": "{% $inputs.preLaunchCoverageEst %}",
-                  "normalDupFracEst": "{% $inputs.preLaunchDupFracEst %}",
-                  "tumorCoverageEst": "{% $inputs.tumorPreLaunchCoverageEst %}",
-                  "tumorDupFracEst": "{% $inputs.tumorPreLaunchDupFracEst %}"
+                  "normalCoverageEst": "{% $tags.preLaunchCoverageEst %}",
+                  "normalDupFracEst": "{% $tags.preLaunchDupFracEst %}",
+                  "tumorCoverageEst": "{% $tags.tumorPreLaunchCoverageEst %}",
+                  "tumorDupFracEst": "{% $tags.tumorPreLaunchDupFracEst %}"
                 }
               },
               "Retry": [
@@ -1328,7 +1328,7 @@
                   "JitterStrategy": "FULL"
                 }
               ],
-              "Output": "{% $states.result.Payload %}",
+              "Output": "{% $states.result.Payload ? $states.result.Payload : {} %}",
               "End": true
             },
             "Has tumor placeholder (downsampling)": {

--- a/app/step-functions-templates/populate_draft_data_sfn_template.asl.json
+++ b/app/step-functions-templates/populate_draft_data_sfn_template.asl.json
@@ -1061,7 +1061,7 @@
     },
     "Add qc tags": {
       "Type": "Parallel",
-      "Next": "Put DRAFT update event",
+      "Next": "Add in downsampling to alignment options inputs",
       "Branches": [
         {
           "StartAt": "Get coverage and dup-frac estimates",
@@ -1282,6 +1282,75 @@
       ],
       "Assign": {
         "tags": "{% /* https://try.jsonata.org/05K2l3beH */\n/* List to merge together */\n[\n    /* Start with the tags */\n    $tags,\n    /* Merge the results list together */\n    $merge($states.result)\n] \n/* Then merge these initial tags with states.result  */\n~> $merge\n/* Remove any keys with values */\n~> $sift(function($v, $k){$v != null}) %}"
+      }
+    },
+    "Add in downsampling to alignment options inputs": {
+      "Type": "Parallel",
+      "Next": "Put DRAFT update event",
+      "Branches": [
+        {
+          "StartAt": "Has tumor rgid list (add in downsampling)",
+          "States": {
+            "Has tumor rgid list (add in downsampling)": {
+              "Type": "Choice",
+              "Choices": [
+                {
+                  "Condition": "{% $tags.tumorFastqRgidList ? true : false %}",
+                  "Comment": "Has tumor inputs",
+                  "Next": "Add downsampling"
+                }
+              ],
+              "Default": "Has tumor placeholder (downsampling)"
+            },
+            "Add downsampling": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::lambda:invoke",
+              "Arguments": {
+                "FunctionName": "${__calculate_downsampling_ratios_lambda_function_arn__}",
+                "Payload": {
+                  "normalCoverageEst": "{% $inputs.preLaunchCoverageEst %}",
+                  "normalDupFracEst": "{% $inputs.preLaunchDupFracEst %}",
+                  "tumorCoverageEst": "{% $inputs.tumorPreLaunchCoverageEst %}",
+                  "tumorDupFracEst": "{% $inputs.tumorPreLaunchDupFracEst %}"
+                }
+              },
+              "Retry": [
+                {
+                  "ErrorEquals": [
+                    "Lambda.ServiceException",
+                    "Lambda.AWSLambdaException",
+                    "Lambda.SdkClientException",
+                    "Lambda.TooManyRequestsException"
+                  ],
+                  "IntervalSeconds": 1,
+                  "MaxAttempts": 3,
+                  "BackoffRate": 2,
+                  "JitterStrategy": "FULL"
+                }
+              ],
+              "Output": "{% $states.result.Payload %}",
+              "End": true
+            },
+            "Has tumor placeholder (downsampling)": {
+              "Type": "Pass",
+              "End": true,
+              "Output": {}
+            }
+          }
+        },
+        {
+          "StartAt": "Downsampling placeholder",
+          "States": {
+            "Downsampling placeholder": {
+              "Type": "Pass",
+              "End": true,
+              "Output": {}
+            }
+          }
+        }
+      ],
+      "Assign": {
+        "inputs": "{% (\n    /* Assign results to new alignment options dict */\n    $newAlignmentOptions := ( [ $states.result ] ~> $merge );\n    $inputs.alignmentOptions ? \n    /* Consider when alignment options is already an input */\n    (\n        $inputs ~> \n        | alignmentOptions | $newAlignmentOptions |\n    ) : \n    /* When Alignment options is not already an input */\n    (\n        $inputs ~> \n        | $ | { \"alignmentOptions\": $newAlignmentOptions } |\n    )\n) %}"
       }
     },
     "Put DRAFT update event": {

--- a/infrastructure/stage/lambda/interfaces.ts
+++ b/infrastructure/stage/lambda/interfaces.ts
@@ -16,6 +16,7 @@ export type LambdaNameList =
   | 'getQcSummaryStatsFromRgidList'
   | 'checkNtsmInternal'
   | 'checkNtsmExternal'
+  | 'calculateDownsamplingRatios'
   // Validation Functions
   | 'validateDraftCompleteSchema'
   | 'postSchemaValidation'
@@ -40,6 +41,7 @@ export const lambdaNameList: LambdaNameList[] = [
   'getQcSummaryStatsFromRgidList',
   'checkNtsmInternal',
   'checkNtsmExternal',
+  'calculateDownsamplingRatios',
   // Validation Functions
   'validateDraftCompleteSchema',
   'postSchemaValidation',
@@ -92,6 +94,9 @@ export const lambdaRequirementsMap: Record<LambdaNameList, LambdaRequirements> =
   },
   checkNtsmExternal: {
     needsOrcabusApiTools: true,
+  },
+  calculateDownsamplingRatios: {
+    // Just some quick maths!
   },
   // Validation Functions
   validateDraftCompleteSchema: {

--- a/infrastructure/stage/step-functions/interfaces.ts
+++ b/infrastructure/stage/step-functions/interfaces.ts
@@ -83,6 +83,7 @@ export const stepFunctionToLambdasMap: Record<StateMachineNameList, LambdaNameLi
     'getQcSummaryStatsFromRgidList',
     'checkNtsmInternal',
     'checkNtsmExternal',
+    'calculateDownsamplingRatios',
     'getProjectBaseUriFromProjectId',
   ],
   validateDraftDataAndPutReadyEvent: ['validateDraftCompleteSchema', 'postSchemaValidation'],


### PR DESCRIPTION
We shouldn't exceed a 3:1 ratio of tumor/normal coverage, hence we restrict the downsampling ratio to 3:1 if its any higher. We also prevent the normal coverage from exceeding the tumor coverage. We also document any downsampling in the OrcaUI