### PR TITLE
Enhances manual pipeline execution with custom inputs

### DIFF
--- a/docs/operation/SOP/PM.DWD.1/PM.DWD.1-ManualPipelineExecution.md
+++ b/docs/operation/SOP/PM.DWD.1/PM.DWD.1-ManualPipelineExecution.md
@@ -35,12 +35,37 @@ For convenience, we provide a shell script that generates and optionally submits
 
 - Familiarise yourself with the script and its parameters: [generate-WRU-draft.sh --help](./generate-WRU-draft.sh)
   - Set the engine parameters (if necessary) and library id(s) in the positional arguments.
+  - If you need to explicitly provide input data (e.g. to specify a particular upstream BAM file when multiple exist), use the `--input-data` parameter with a JSON file.
 - Execute the script (e.g. `bash generate-WRU-draft.sh --comment 'Manual rerun' <your_tn_library_id> <your_normal_library_id>`)
   - Note: AWS credentials need to be set on the environment as does your PORTAL_TOKEN (see the script for details)
   - Use the comment parameter to explain the reason for the manual run, this will be visible in the Portal and helpful for future reference.
 - The script should produce the JSON output of the DRAFT event that can be inspected to double check that reflects the intended request
   - Take note of the generated `workflowRunName` or `portalRunId` and the URL to the OrcaBus Portal view of the workflow.
   - You can have the script save the output json file by using the `--save-draft-payload` method.
+
+### Using --input-data
+
+The populate draft data service will try to auto-populate inputs based on the information it already has.
+This may have unintended consequences if there exists two downstream analyses and you want inputs from one specific analysis.
+In this circumstance it is recommended to use `--input-data <json_file>` to provide an existing data object to populate.
+
+Example input data JSON file:
+
+```json
+{
+  "inputs": {
+    "tumorDnaBamUri": "s3://path/to/specific/tumor.bam"
+  }
+}
+```
+
+Example usage with `--input-data`:
+
+```bash
+bash generate-WRU-draft.sh tumor_library_id normal_library_id \
+  --comment 'Redriving with specific inputs' \
+  --input-data /path/to/input_data.json
+```
 
 Confirmation
 --------------------------------------------------------------------------------

--- a/docs/operation/SOP/PM.DWD.1/PM.DWD.1-ManualPipelineExecution.md
+++ b/docs/operation/SOP/PM.DWD.1/PM.DWD.1-ManualPipelineExecution.md
@@ -1,6 +1,6 @@
 Manual Pipeline Execution
 ================================================================================
-- Version: 2026.03.05
+- Version: 2026.06.25
 - Contact: Alexis Lucattini, [alexisl@unimelb.edu.au](mailto:alexisl@unimelb.edu.au)
 
 

--- a/docs/operation/SOP/PM.DWD.1/generate-WRU-draft.sh
+++ b/docs/operation/SOP/PM.DWD.1/generate-WRU-draft.sh
@@ -652,6 +652,13 @@ engine_parameters=$( \
     ' \
 )
 
+# Load input data if provided
+if [[ -n "${INPUT_DATA_FILE}" ]]; then
+  input_data_json_str="$(jq < "${INPUT_DATA_FILE}")"
+else
+  input_data_json_str="null"
+fi
+
 # Generate the event
 lambda_payload="$( \
   jq --null-input --raw-output \
@@ -661,6 +668,7 @@ lambda_payload="$( \
     --argjson libraries "${libraries}" \
     --argjson engineParameters "${engine_parameters}" \
     --argjson disableSvCalling "${DISABLE_SV_CALLING}" \
+    --argjson inputData "${input_data_json_str}" \
     '
     {
       "status": "DRAFT",
@@ -672,7 +680,8 @@ lambda_payload="$( \
     } |
     if (
       $disableSvCalling or
-      ( ($engineParameters | length) > 0 )
+      ( ($engineParameters | length) > 0 ) or
+      $inputData
     ) then
       # We have a payload to add
       # So we initialise with a version and an empty data object
@@ -680,15 +689,22 @@ lambda_payload="$( \
         "version": $payloadVersion,
         "data": {}
       } |
+      # Check if we have input data to merge first (as a base)
+      if $inputData then
+        .["payload"]["data"] = ($inputData * .["payload"]["data"])
+      end |
       # Separately edit each of the payload data fields
       # Check if the SV calling is to be disabled
       # And edit inputs.somaticSvCallerOptions if so
       if $disableSvCalling then
-        .["payload"]["data"]["inputs"] = {
-          "somaticSvCallerOptions": {
-            "enableSv": false
+        .["payload"]["data"]["inputs"] = (
+          (.["payload"]["data"]["inputs"] // {}) +
+          {
+            "somaticSvCallerOptions": {
+              "enableSv": false
+            }
           }
-        }
+        )
       end |
       # Check if there are engine parameters to add
       # And set engineParameters if so

--- a/docs/operation/SOP/PM.DWD.1/generate-WRU-draft.sh
+++ b/docs/operation/SOP/PM.DWD.1/generate-WRU-draft.sh
@@ -16,6 +16,7 @@ PROJECT_ID=""
 DISABLE_SV_CALLING="false"
 COMMENT=""  # Use -c or --comment to set a comment to be added to the payload
 SAVE_DRAFT_PAYLOAD=""
+INPUT_DATA_FILE=""
 
 # Workflow constants
 WORKFLOW_NAME="dragen-wgts-dna"
@@ -470,6 +471,15 @@ while [[ $# -gt 0 ]]; do
       ;;
     --code-version=*)
       CODE_VERSION="${1#*=}"
+      shift
+      ;;
+    # Input data
+    --input-data)
+      INPUT_DATA_FILE="$2"
+      shift 2
+      ;;
+    --input-data=*)
+      INPUT_DATA_FILE="${1#*=}"
       shift
       ;;
     # Positional arguments (library IDs)

--- a/docs/operation/SOP/PM.DWD.1/generate-WRU-draft.sh
+++ b/docs/operation/SOP/PM.DWD.1/generate-WRU-draft.sh
@@ -60,6 +60,7 @@ generate-WRU-draft.sh (library_id)...
                       [--save-draft-payload <output_file>]
                       [--workflow-version <workflow_version>]
                       [--code-version <code_version>]
+                      [--input-data <input_data_path>]
                       [--disable-sv-calling]
 
 Description:
@@ -73,6 +74,18 @@ You will also need to ensure that the ICA pipeline ID attributed to the workflow
 available in the ICA project id specified.
 
 The output uri prefix, logs uri prefixes must be set to a location inside the s3 prefix that the ICA project is mounted on.
+
+Input data note:
+The populate draft data service will try to auto-populate inputs based on the information it already has.
+This may include things such as downsampling when tumor coverage is significantly larger than the normal coverage.
+In this circumstance it is recommended to use the '--input-data <json_file>' to generate an existing data object to populate, for example:
+{
+  \"inputs\": {
+    \"somaticAlignmentOptions\": {
+      \"enableFractionalDownSampler\": false
+    }
+  }
+}
 
 Positional arguments:
   library_id:   One or more library IDs to link to the WorkflowRunUpdate event.
@@ -89,6 +102,9 @@ Keyword arguments:
                                                             but can also be set to 4.4.6, this is particularly useful for SV calling.
   --code-version=<code_version>                  (Optional) Set the code version to pull a particular workflow object.
                                                             Required if using a workflow version other than the default.
+  --input-data=<input_data_file>                 (Optional) Add existing input data to the data section of the payload.
+                                                            This might be used to explicitly set input files.
+                                                            See input data note for more information.
   --disable-sv-calling:                          (Optional) Disable structural variant calling for the somatic step of the pipeline.
 
 Environment:
@@ -119,6 +135,9 @@ bash generate-WRU-draft.sh tumor_library_id normal_library_id \\
   --logs-uri-prefix s3://project-bucket/logs/dragen-wgts-dna \\
   --project-id project-uuid-1234-abcd \\
   --save-draft-payload tumor_library_id__normal_library_id__draft_payload.json
+bash generate-WRU-draft.sh tumor_library_id normal_library_id \\
+  --comment 'Redriving with specific inputs' \\
+  --input-data /path/to/input_data.json
 "
 }
 

--- a/docs/operation/SOP/PM.DWD.1/generate-WRU-draft.sh
+++ b/docs/operation/SOP/PM.DWD.1/generate-WRU-draft.sh
@@ -26,7 +26,7 @@ CODE_VERSION="724101a"
 PAYLOAD_VERSION="2025.06.24"
 
 # SOP constants
-SOP_VERSION="2026.03.05"
+SOP_VERSION="2026.06.25"
 SOP_ID="PM.DWD.1"
 GITHUB_REPO="OrcaBus/service-dragen-wgts-dna-pipeline-manager"
 THIS_SCRIPT_PATH="docs/operation/SOP/${SOP_ID}/generate-WRU-draft.sh"

--- a/docs/operation/SOP/PM.DWD.1/generate-WRU-draft.sh
+++ b/docs/operation/SOP/PM.DWD.1/generate-WRU-draft.sh
@@ -519,6 +519,23 @@ if [[ -n "${SAVE_DRAFT_PAYLOAD}" ]]; then
   fi
 fi
 
+# Check input data file is valid if provided
+if [[ -n "${INPUT_DATA_FILE}" ]]; then
+  # Check if input data file exists
+  if [[ ! -f "${INPUT_DATA_FILE}" ]]; then
+    echo_stderr "Error: Input data file '${INPUT_DATA_FILE}' does not exist. Exiting."
+    print_usage
+    exit 1
+  fi
+
+  # Check input data is in json format
+  if ! jq -e 'type == "object"' < "${INPUT_DATA_FILE}" >/dev/null 2>&1; then
+    echo_stderr "Error: Input data file '${INPUT_DATA_FILE}' is not valid JSON or is not an object. Exiting."
+    print_usage
+    exit 1
+  fi
+fi
+
 # Check AWS CLI configuration
 if ! aws sts get-caller-identity --output json > /dev/null 2>&1; then
   echo_stderr "Error: AWS CLI is not configured properly. Please configure your AWS CLI with appropriate credentials and region. Exiting."


### PR DESCRIPTION
The `generate-WRU-draft.sh` script now includes support for a new `--input-data` parameter. This enhancement allows users to provide a JSON file containing explicit input data, which will be merged into the workflow run payload.

This feature addresses scenarios where:
- Auto-populated inputs might lead to unintended consequences, such as automatic downsampling.
- Specific input files, like a particular upstream BAM, need to be explicitly selected when multiple options are available.

Key changes:
- Adds argument parsing and validation for the `--input-data` parameter within `generate-WRU-draft.sh`.
- Integrates robust logic to merge the user-provided JSON into the workflow run payload, ensuring custom inputs are applied correctly.
- Updates the script's `--help` documentation and the `Manual Pipeline Execution` Standard Operating Procedure to detail the new parameter and provide usage examples.