### PR TITLE
Allows overriding fractional downsampling

### DIFF
--- a/app/step-functions-templates/populate_draft_data_sfn_template.asl.json
+++ b/app/step-functions-templates/populate_draft_data_sfn_template.asl.json
@@ -1297,7 +1297,17 @@
                 {
                   "Condition": "{% $tags.tumorFastqRgidList ? true : false %}",
                   "Comment": "Has tumor inputs",
-                  "Next": "Add downsampling"
+                  "Next": "Fractional downsampling not explicitly set to false?"
+                }
+              ],
+              "Default": "Has tumor placeholder (downsampling)"
+            },
+            "Fractional downsampling not explicitly set to false?": {
+              "Type": "Choice",
+              "Choices": [
+                {
+                  "Next": "Add downsampling",
+                  "Condition": "{% $inputs.somaticAlignmentOptions.enableFractionalDownSampler = false ? false : true %}"
                 }
               ],
               "Default": "Has tumor placeholder (downsampling)"


### PR DESCRIPTION
Adds a new conditional check in the Step Function workflow to control fractional downsampling. This enables users to explicitly disable fractional downsampling by setting the `enableFractionalDownSampler` input to `false`, even when tumor inputs are provided. This change provides more granular control over the workflow's behavior.