### PR TITLE
Feature/GitHub action updates

### DIFF
--- a/.github/workflows/pnpm-audit.yml
+++ b/.github/workflows/pnpm-audit.yml
@@ -28,7 +28,7 @@ jobs:
       - run: corepack enable
 
       - name: Install yq
-        uses: mikefarah/yq@master
+        uses: mikefarah/yq@v4.53.3
 
       - name: Check existing open audit PRs
         id: check-existing

--- a/.github/workflows/pnpm-audit.yml
+++ b/.github/workflows/pnpm-audit.yml
@@ -2,8 +2,8 @@ name: pnpm Audit & Auto-fix
 
 on:
   schedule:
-    # Run daily at 06:00 UTC
-    - cron: '0 6 * * *'
+    # Run daily at 00:05 UTC (10:05 AEST) — offset to avoid caching delays on CVE publication
+    - cron: '5 0 * * *'
   workflow_dispatch: {}
 
 permissions:
@@ -26,6 +26,9 @@ jobs:
           cache: 'pnpm'
 
       - run: corepack enable
+
+      - name: Install yq
+        uses: mikefarah/yq@master
 
       - name: Check existing open audit PRs
         id: check-existing
@@ -64,7 +67,7 @@ jobs:
 
           pnpm install --frozen-lockfile --ignore-scripts
 
-          if pnpm audit --prod > /dev/null 2>&1; then
+          if pnpm audit > /dev/null 2>&1; then
             echo "pr_still_valid=true" >> "$GITHUB_OUTPUT"
             echo "Existing PR still passes audit — nothing to do."
           else
@@ -110,7 +113,7 @@ jobs:
           steps.test-existing.outputs.pr_still_valid == 'false'
         run: |
           set -o pipefail
-          if pnpm audit --prod 2>&1 | tee audit-output.txt; then
+          if pnpm audit 2>&1 | tee audit-output.txt; then
             echo "has_vulnerabilities=false" >> "$GITHUB_OUTPUT"
           else
             echo "has_vulnerabilities=true" >> "$GITHUB_OUTPUT"
@@ -122,28 +125,35 @@ jobs:
         run: |
           set -o pipefail
           # Try a standard upgrade to resolve vulnerabilities
-          pnpm upgrade
+          # --ignore-scripts avoids running lifecycle hooks (e.g. prepare: pre-commit install)
+          pnpm upgrade --ignore-scripts
 
           # Re-run audit to see if upgrade resolved issues
-          if pnpm audit --prod 2>&1 | tee audit-after-upgrade.txt; then
+          if pnpm audit 2>&1 | tee audit-after-upgrade.txt; then
             echo "upgrade_fixed=true" >> "$GITHUB_OUTPUT"
           else
             echo "upgrade_fixed=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Attempt pnpm audit --fix (overrides)
+      - name: Attempt pnpm audit --fix=override
         id: audit-fix
         if: steps.upgrade.outputs.upgrade_fixed == 'false'
         run: |
           set -o pipefail
-          # Use pnpm audit --fix to add overrides for vulnerable transitive deps
-          pnpm audit --fix 2>&1 | tee audit-fix-output.txt || true
+          # Remove existing overrides to prevent stale/conflicting ranges accumulating
+          if [ -f pnpm-workspace.yaml ]; then yq -i 'del(.overrides)' pnpm-workspace.yaml; fi
+
+          # Reinstall to regenerate lockfile without old overrides
+          pnpm install --no-frozen-lockfile --ignore-scripts
+
+          # Use pnpm audit --fix=override to add fresh overrides for vulnerable transitive deps
+          pnpm audit --fix=override 2>&1 | tee audit-fix-output.txt || true
 
           # Reinstall with the new overrides
-          pnpm install
+          pnpm install --no-frozen-lockfile --ignore-scripts
 
           # Verify the fix resolved the issues
-          if pnpm audit --prod 2>&1 | tee audit-after-fix.txt; then
+          if pnpm audit 2>&1 | tee audit-after-fix.txt; then
             echo "audit_fix_resolved=true" >> "$GITHUB_OUTPUT"
           else
             echo "audit_fix_resolved=false" >> "$GITHUB_OUTPUT"
@@ -158,7 +168,7 @@ jobs:
           if [[ "${{ steps.upgrade.outputs.upgrade_fixed }}" == "true" ]]; then
             echo "method=pnpm upgrade" >> "$GITHUB_OUTPUT"
           else
-            echo "method=pnpm audit --fix (overrides)" >> "$GITHUB_OUTPUT"
+            echo "method=pnpm audit --fix=override" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create tracking issue
@@ -192,6 +202,10 @@ jobs:
         uses: peter-evans/create-pull-request@v8
         with:
           branch: chore/pnpm-audit-fix-${{ github.run_id }}
+          add-paths: |
+            package.json
+            pnpm-workspace.yaml
+            pnpm-lock.yaml
           commit-message: 'chore: fix security vulnerabilities via ${{ steps.fix-method.outputs.method }}'
           title: 'chore: fix pnpm audit vulnerabilities (${{ github.run_id }})'
           body: |
@@ -204,7 +218,7 @@ jobs:
             Closes #${{ steps.create-issue.outputs.issue_number }}
 
             ### What happened
-            - `pnpm audit` detected vulnerabilities in production dependencies
+            - `pnpm audit` detected vulnerabilities in dependencies
             - The workflow attempted to resolve them automatically
             - All vulnerabilities were resolved
 
@@ -214,6 +228,7 @@ jobs:
             - Merge when satisfied
           labels: security,dependencies
           delete-branch: true
+          sign-commits: true
 
       - name: Create issue for unresolved vulnerabilities
         if: |
@@ -256,7 +271,7 @@ jobs:
 
           ### Remediation attempts
           1. ❌ \`pnpm upgrade\` — did not resolve all issues
-          2. ❌ \`pnpm audit --fix\` (overrides) — did not resolve all issues
+          2. ❌ \`pnpm audit --fix=override\` — did not resolve all issues
 
           ### Audit output
           \`\`\`

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,14 +1,13 @@
 name: Pull Request Tests
 
 on:
-  merge_group:
+  merge_group: {}
   pull_request:
     types:
       - opened
       - reopened
       - synchronize
       - ready_for_review
-      - auto_merge_enabled
     branches:
       - main
 
@@ -73,7 +72,7 @@ jobs:
     outputs:
       should_test: ${{ steps.filter.outputs.code }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: dorny/paths-filter@v4
@@ -91,9 +90,12 @@ jobs:
               - 'test/**'
               - 'Makefile'
               - '.github/**'
+              - 'cdk.json'
+              - 'tsconfig.json'
+              - 'jest.config.*'
   test-iac:
     runs-on: ubuntu-22.04-arm
-    # Template service base is broken with
+    # Excluded for template-service-base which has no application code to test
     if: >-
       !github.event.pull_request.draft &&
       github.repository != 'OrcaBus/template-service-base' &&
@@ -118,13 +120,21 @@ jobs:
   # This is the job you set as "required" in branch protection
   ci-gate:
     runs-on: ubuntu-latest
-    needs: test-iac
+    needs: [pre-commit-lint-security, check-changes, test-iac]
     if: always()
     steps:
       - name: Check results
         run: |
-          if [[ "${{ needs.test-iac.result }}" == "failure" ]]; then
-            echo "Tests failed"
+          if [[ "${{ needs.pre-commit-lint-security.result }}" != "success" && "${{ needs.pre-commit-lint-security.result }}" != "skipped" ]]; then
+            echo "Lint/security checks did not succeed (result: ${{ needs.pre-commit-lint-security.result }})"
+            exit 1
+          fi
+          if [[ "${{ needs.check-changes.result }}" != "success" ]]; then
+            echo "Change detection did not succeed (result: ${{ needs.check-changes.result }})"
+            exit 1
+          fi
+          if [[ "${{ needs.test-iac.result }}" != "success" && "${{ needs.test-iac.result }}" != "skipped" ]]; then
+            echo "Tests did not succeed (result: ${{ needs.test-iac.result }})"
             exit 1
           fi
           echo "CI passed (tests passed or were skipped)"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "organization": true
   },
   "license": "MIT",
-  "packageManager": "pnpm@11.6.0+sha512.9a36518224080c6fe5165afdcfe79bfa118c29be703f3f462b1e32efe1e98e47e8750b148e08286250aad4113cc7993ca413c4e2cd447752708c2ee5751bc95f",
+  "packageManager": "pnpm@11.17.0+sha512.cca3cea332ad254bb84145f966d19f4879615210346fc92c79a047f23a0d7b3cca3c3792f0076ba1f1831d277efbcf0a9119b31a9a60eca7fb3d6231f331ef72",
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/jest": "^30.0.0",


### PR DESCRIPTION
## Summary

Improves the reliability and correctness of both CI workflows and bumps pnpm to 11.17.0.

## Changes

**PR tests workflow (`pr-tests.yml`)**
- Update `actions/checkout` from v4 to v7
- Remove `auto_merge_enabled` trigger type (redundant — `synchronize` already covers this)
- Normalize `merge_group` trigger syntax to `merge_group: {}`
- Add `cdk.json`, `tsconfig.json`, `jest.config.*` to path filters so config changes trigger tests
- Strengthen `ci-gate` job to verify all upstream jobs (`pre-commit-lint-security`, `check-changes`, `test-iac`) rather than only checking `test-iac`

**Audit workflow (`pnpm-audit.yml`)**
- Shift schedule from 06:00 to 00:05 UTC to avoid CVE publication caching delays
- Audit all dependencies (previously `--prod` only) for complete vulnerability coverage
- Use `pnpm audit --fix=override` with fresh override cleanup — removes stale overrides from `pnpm-workspace.yaml` before re-applying, preventing range conflicts
- Add `--ignore-scripts` to `pnpm install`/`upgrade` to skip lifecycle hooks (e.g. `pre-commit install`) in CI
- Install `yq` for safe YAML manipulation of `pnpm-workspace.yaml`
- Scope `create-pull-request` to only commit `package.json`, `pnpm-workspace.yaml`, `pnpm-lock.yaml`
- Enable signed commits on auto-generated PRs

**Package manager**
- Bump pnpm from 11.6.0 to 11.17.0

## Testing

- Pre-commit hooks pass on all commits
- No application code changes — CDK tests are unaffected