### PR TITLE
feat: add application tests framework for Lambda and Step Functions

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -117,10 +117,32 @@ jobs:
 
       - run: pnpm test
 
+  test-app:
+    runs-on: ubuntu-22.04-arm
+    if: >-
+      !github.event.pull_request.draft &&
+      needs.check-changes.outputs.should_test == 'true'
+    needs: check-changes
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.14'
+
+      - name: Install test dependencies
+        run: pip install -r app/tests/requirements-test.txt --quiet
+
+      - name: Run Lambda unit tests
+        run: python -m pytest app/lambdas/tests/ -v --tb=short
+
+      - name: Run ASL validation tests
+        run: python -m pytest app/step-functions-templates/tests/test_asl_validation.py -v --tb=short
+
   # This is the job you set as "required" in branch protection
   ci-gate:
     runs-on: ubuntu-latest
-    needs: [pre-commit-lint-security, check-changes, test-iac]
+    needs: [pre-commit-lint-security, check-changes, test-iac, test-app]
     if: always()
     steps:
       - name: Check results
@@ -134,7 +156,11 @@ jobs:
             exit 1
           fi
           if [[ "${{ needs.test-iac.result }}" != "success" && "${{ needs.test-iac.result }}" != "skipped" ]]; then
-            echo "Tests did not succeed (result: ${{ needs.test-iac.result }})"
+            echo "IAC tests did not succeed (result: ${{ needs.test-iac.result }})"
             exit 1
           fi
-          echo "CI passed (tests passed or were skipped)"
+          if [[ "${{ needs.test-app.result }}" != "success" && "${{ needs.test-app.result }}" != "skipped" ]]; then
+            echo "App tests did not succeed (result: ${{ needs.test-app.result }})"
+            exit 1
+          fi
+          echo "CI passed (all checks passed or were skipped)"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test deep scan
+.PHONY: test test-app test-app-all check fix install
 
 check:
 	@pnpm audit
@@ -15,3 +15,9 @@ install:
 
 test:
 	@pnpm test
+
+test-app:
+	@pytest -m "not sfn_teststate" --tb=short
+
+test-app-all:
+	@pytest --tb=short

--- a/README-tests.md
+++ b/README-tests.md
@@ -1,0 +1,126 @@
+# Test Documentation
+
+This document provides the high-level test directory layout for `service-dragen-wgts-dna-pipeline-manager`. For detailed Python test documentation (fixtures, markers, how to add tests, CI), see [app/tests/README.md](app/tests/README.md).
+
+## Test Directory Layout
+
+```
+service-dragen-wgts-dna-pipeline-manager/
+├── conftest.py                              # Root conftest — untested Lambda detection warnings
+├── pytest.ini                               # pytest configuration (markers, test paths, options)
+├── app/
+│   └── tests/
+│       ├── requirements-test.txt            # Python test dependencies (shared across all app tests)
+│       └── README.md                        # Detailed Python test documentation
+├── app/lambdas/tests/                       # Lambda unit tests (Python)
+├── app/step-functions-templates/tests/      # ASL validation + SFN Local integration tests (Python)
+├── smoke-tests/                             # Post-deployment smoke tests (Python)
+│   ├── run-smoke-tests.py                   # Smoke test runner script
+│   └── smoke-test-config.json               # Configuration (stack names, expected counts, permissions)
+└── test/                                    # CDK/Jest infrastructure tests (TypeScript)
+    ├── stage.test.ts
+    ├── toolchain.test.ts
+    └── utils.ts
+```
+
+## Test Categories
+
+| Category              | Language   | Location                              | Runner          | When                          |
+| --------------------- | ---------- | ------------------------------------- | --------------- | ----------------------------- |
+| Lambda unit tests     | Python     | `app/lambdas/tests/`                  | pytest          | PR / pre-merge                |
+| ASL validation        | Python     | `app/step-functions-templates/tests/` | pytest          | PR / pre-merge                |
+| SFN Local integration | Python     | `app/step-functions-templates/tests/` | pytest + Docker | PR / pre-merge                |
+| CDK infrastructure    | TypeScript | `test/`                               | Jest            | PR / pre-merge                |
+| Smoke tests           | Python     | `smoke-tests/`                        | CodeBuild       | Post-deployment (Beta, Gamma) |
+
+## Quick Start
+
+```bash
+# Python tests — install dependencies then run
+pip install -r app/tests/requirements-test.txt
+pytest
+
+# CDK/Jest tests
+pnpm test
+
+# Smoke tests (run locally against a deployed environment)
+python3 smoke-tests/run-smoke-tests.py --stage Beta --region ap-southeast-2
+```
+
+## Smoke Tests
+
+Smoke tests run after deployment to Beta and Gamma environments as a CodeBuild step in the CI/CD pipeline. They verify that deployed resources are correctly provisioned, accessible, and properly wired together.
+
+### When They Run
+
+The smoke tests are integrated into the `StatelessDragenWgtsDnaPipeline` CodePipeline:
+
+1. Code merges to `main`
+2. CDK synth + unit tests pass
+3. **Deploy to Beta** → **Smoke tests run against Beta**
+4. **Deploy to Gamma** → **Smoke tests run against Gamma**
+5. Deploy to Prod (no smoke tests — validated in prior stages)
+
+If smoke tests fail, the pipeline halts and the deployment does not promote to the next environment.
+
+### What They Check
+
+The smoke test discovers all resources from CloudFormation stacks rather than maintaining a hardcoded list:
+
+| Check                          | Description                                                                                                                                                         |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Resource discovery**         | Queries `{stage}-StatelessDragenWgtsDnaPipelineManager` and `{stage}-StatefulDragenWgtsDnaPipeline` stacks via CloudFormation `ListStackResources`                  |
+| **Resource counts**            | Verifies expected number of Lambdas (22) and state machines (4) are deployed                                                                                        |
+| **Lambda DryRun**              | Invokes each Lambda with `InvocationType=DryRun` to confirm it's reachable and returns HTTP 204                                                                     |
+| **State machine status**       | Calls `DescribeStateMachine` and verifies `status=ACTIVE` with a non-null definition                                                                                |
+| **No unresolved placeholders** | Scans each state machine definition for `__placeholder__` tokens that should have been substituted by CDK                                                           |
+| **IAM permissions**            | Inspects each state machine's IAM role policies to confirm expected actions are granted (`lambda:InvokeFunction`, `events:PutEvents`, `ssm:GetParameter`)           |
+| **SSM parameter readability**  | Reads each SSM parameter discovered from the stateful stack                                                                                                         |
+| **SSM cross-reference**        | Extracts SSM parameter paths referenced in state machine definitions and Lambda environment variables, then verifies each one exists in the deployed stateful stack |
+
+### Configuration
+
+The configuration lives in `smoke-tests/smoke-test-config.json`:
+
+```json
+{
+  "stateless_stack_name": "{stage_prefix}-StatelessDragenWgtsDnaPipelineManager",
+  "stateful_stack_name": "{stage_prefix}-StatefulDragenWgtsDnaPipeline",
+  "expected_lambda_count": 22,
+  "expected_state_machine_count": 4,
+  "ssm_parameter_prefix": "/orcabus/workflows/dragen-wgts-dna/",
+  "state_machine_permissions": {
+    "populateDraftData": ["lambda:InvokeFunction", "ssm:GetParameter", "events:PutEvents"],
+    "validateDraftDataAndPutReadyEvent": ["lambda:InvokeFunction", "events:PutEvents"],
+    "readyEventToIcav2WesRequestEvent": ["lambda:InvokeFunction", "events:PutEvents"],
+    "icav2WesEventToWrscEvent": ["lambda:InvokeFunction", "events:PutEvents"]
+  }
+}
+```
+
+The `{stage_prefix}` placeholder is resolved at runtime based on the `--stage` argument (e.g. `OrcaBusBeta`, `OrcaBusGamma`).
+
+### Running Locally
+
+```bash
+# Using default AWS credentials (must have access to the target account)
+python3 smoke-tests/run-smoke-tests.py --stage Beta
+
+# With cross-account role assumption
+python3 smoke-tests/run-smoke-tests.py \
+    --role-arn arn:aws:iam::ACCOUNT_ID:role/OrcaBusBeta-CrossAccountSmokeTestRole \
+    --stage Beta \
+    --region ap-southeast-2
+```
+
+### Required IAM Permissions (Cross-Account Role)
+
+The smoke test role in the target account needs:
+
+- `cloudformation:ListStackResources` — discover resources from stacks
+- `lambda:InvokeFunction` (DryRun) — validate Lambda accessibility
+- `lambda:GetFunctionConfiguration` — read environment variables for SSM cross-referencing
+- `states:DescribeStateMachine` — check state machine status and definition
+- `ssm:GetParameter` — verify SSM parameters are readable
+- `iam:ListRolePolicies`, `iam:GetRolePolicy` — inspect state machine role inline policies
+- `iam:ListAttachedRolePolicies`, `iam:GetPolicy`, `iam:GetPolicyVersion` — inspect managed policies

--- a/app/lambdas/tests/conftest.py
+++ b/app/lambdas/tests/conftest.py
@@ -1,0 +1,45 @@
+"""Service-specific test fixtures for service-dragen-wgts-dna-pipeline-manager.
+
+The shared plugin fixtures (AWS mocks, lambda_context, event_builder) are
+auto-registered via the orcabus_pipeline_test_utils pytest plugin entry point.
+No explicit import of those fixtures is needed here.
+
+This file provides service-specific fixtures for dragen-wgts-dna tests.
+"""
+
+import pytest
+
+
+# -- Service-specific constants ------------------------------------------------
+
+SERVICE_NAME = "dragen-wgts-dna"
+EVENT_SOURCE = "orcabus.dragenwgtsdna"
+EVENT_BUS_NAME = "OrcaBusMain"
+SSM_PREFIX = "/orcabus/workflows/dragen-wgts-dna/"
+
+
+# -- Service-specific fixtures -------------------------------------------------
+
+
+@pytest.fixture
+def service_name() -> str:
+    """Return the workflow service name for dragen-wgts-dna."""
+    return SERVICE_NAME
+
+
+@pytest.fixture
+def event_source() -> str:
+    """Return the EventBridge event source for dragen-wgts-dna."""
+    return EVENT_SOURCE
+
+
+@pytest.fixture
+def event_bus_name() -> str:
+    """Return the EventBridge event bus name."""
+    return EVENT_BUS_NAME
+
+
+@pytest.fixture
+def ssm_prefix() -> str:
+    """Return the SSM parameter prefix for dragen-wgts-dna."""
+    return SSM_PREFIX

--- a/app/lambdas/tests/examples/__init__.py
+++ b/app/lambdas/tests/examples/__init__.py
@@ -1,0 +1,2 @@
+# Example test templates demonstrating common Lambda testing patterns.
+# These are self-contained reference implementations for developers.

--- a/app/lambdas/tests/examples/test_api_call_example.py
+++ b/app/lambdas/tests/examples/test_api_call_example.py
@@ -1,0 +1,258 @@
+"""
+Example: Testing a Lambda that Makes External API Calls
+========================================================
+
+This template demonstrates how to test a Lambda function that calls
+external services (e.g., OrcaBus Metadata API, ICAv2 API). The key
+technique is patching the external dependency at the module level
+so the handler's logic can be tested in isolation.
+
+Pattern:
+    - Patch external API calls (e.g., orcabus_api_tools functions)
+    - Provide controlled return values for each mocked call
+    - Assert the handler correctly processes and transforms API responses
+    - Test error handling when external calls fail
+
+Real-world example: get_libraries_py
+    - Calls orcabus_api_tools.metadata.get_library_from_library_orcabus_id()
+    - Processes library metadata to extract phenotype and readset info
+    - Returns structured output based on tumor/normal classification
+
+Fixtures used:
+    - event_builder: Wraps a dict payload into a Lambda event
+    - lambda_context: Provides a mock Lambda context object
+
+Note: For Lambdas that call AWS services directly (boto3), prefer
+using the moto-based fixtures (mock_ssm_client, mock_s3_client, etc.)
+instead of patching. See test_validation_example.py for that pattern.
+"""
+
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup
+#
+# The get_libraries Lambda depends on the `orcabus_api_tools` layer package
+# which is not installed in the local test environment. We mock the layer
+# module before importing the handler so the import succeeds.
+# This is the standard pattern for testing Lambdas that use Lambda Layers.
+# ---------------------------------------------------------------------------
+LAMBDA_DIR = Path(__file__).resolve().parents[2] / "get_libraries_py"
+
+# Mock the Lambda Layer dependency before importing the handler
+_mock_api_tools = ModuleType("orcabus_api_tools")
+_mock_metadata = ModuleType("orcabus_api_tools.metadata")
+_mock_metadata.get_library_from_library_orcabus_id = MagicMock()
+_mock_api_tools.metadata = _mock_metadata
+
+# The models module exports TypedDict types used for type hints.
+# We provide plain dict as a stand-in since TypedDicts are just dicts at runtime.
+_mock_models = ModuleType("orcabus_api_tools.metadata.models")
+_mock_models.LibraryBase = dict
+_mock_models.Library = dict
+_mock_metadata.models = _mock_models
+
+sys.modules.setdefault("orcabus_api_tools", _mock_api_tools)
+sys.modules.setdefault("orcabus_api_tools.metadata", _mock_metadata)
+sys.modules.setdefault("orcabus_api_tools.metadata.models", _mock_models)
+
+sys.path.insert(0, str(LAMBDA_DIR))
+
+from get_libraries import handler  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Test data factories
+# ---------------------------------------------------------------------------
+
+
+def make_library_with_readsets(library_id: str, orcabus_id: str, rgids: list[str]):
+    """Create a library dict with readsets as it appears in the Lambda event."""
+    return {
+        "libraryId": library_id,
+        "orcabusId": orcabus_id,
+        "readsets": [
+            {"orcabusId": f"rs.{rgid}", "rgid": rgid}
+            for rgid in rgids
+        ],
+    }
+
+
+def make_library_metadata(library_id: str, phenotype: str):
+    """Create a library metadata dict as returned by the OrcaBus Metadata API."""
+    return {
+        "libraryId": library_id,
+        "phenotype": phenotype,
+        "type": "WGS",
+        "assay": "TsqNano",
+        "workflow": "research",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests: Single library (germline) — no API call needed
+# ---------------------------------------------------------------------------
+
+
+class TestSingleLibraryNoApiCall:
+    """When only one library is provided, no external API call is made."""
+
+    def test_single_library_returns_library_id_and_rgids(
+        self, event_builder, lambda_context
+    ):
+        """A single library returns its ID and FASTQ readgroup IDs directly."""
+        event = event_builder({
+            "libraries": [
+                make_library_with_readsets(
+                    library_id="L2401001",
+                    orcabus_id="lib.abc123",
+                    rgids=["RGID001", "RGID002"],
+                )
+            ]
+        })
+        ctx = lambda_context(function_name="get-libraries")
+
+        result = handler(event, ctx)
+
+        assert result["libraryId"] == "L2401001"
+        assert result["fastqRgidList"] == ["RGID001", "RGID002"]
+        # Should NOT have tumor fields
+        assert "tumorLibraryId" not in result
+
+    def test_single_library_no_readsets_returns_empty_list(
+        self, event_builder, lambda_context
+    ):
+        """A library with no readsets returns an empty RGID list."""
+        event = event_builder({
+            "libraries": [{
+                "libraryId": "L2401001",
+                "orcabusId": "lib.abc123",
+                "readsets": None,
+            }]
+        })
+        ctx = lambda_context()
+
+        result = handler(event, ctx)
+
+        assert result["libraryId"] == "L2401001"
+        assert result["fastqRgidList"] == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: Two libraries (tumor/normal pair) — requires API call
+# ---------------------------------------------------------------------------
+
+
+class TestTumorNormalPairWithMockedApi:
+    """When two libraries are provided, the handler calls the Metadata API
+    to determine which is tumor and which is normal."""
+
+    @patch("get_libraries.get_library_from_library_orcabus_id")
+    def test_tumor_normal_pair_classified_correctly(
+        self, mock_get_library, event_builder, lambda_context
+    ):
+        """Two libraries are correctly classified by phenotype via API lookup."""
+        # Arrange: Mock the API to return phenotype metadata
+        mock_get_library.side_effect = [
+            make_library_metadata("L2401001", "tumor"),
+            make_library_metadata("L2401002", "normal"),
+        ]
+
+        event = event_builder({
+            "libraries": [
+                make_library_with_readsets("L2401001", "lib.tumor1", ["RGID_T1"]),
+                make_library_with_readsets("L2401002", "lib.normal1", ["RGID_N1", "RGID_N2"]),
+            ]
+        })
+        ctx = lambda_context()
+
+        # Act
+        result = handler(event, ctx)
+
+        # Assert: Normal library is primary, tumor is secondary
+        assert result["libraryId"] == "L2401002"
+        assert result["tumorLibraryId"] == "L2401001"
+        assert result["fastqRgidList"] == ["RGID_N1", "RGID_N2"]
+        assert result["tumorFastqRgidList"] == ["RGID_T1"]
+
+        # Verify the API was called for each library
+        assert mock_get_library.call_count == 2
+
+    @patch("get_libraries.get_library_from_library_orcabus_id")
+    def test_missing_tumor_raises_error(
+        self, mock_get_library, event_builder, lambda_context
+    ):
+        """If no tumor library is found in the pair, raise ValueError."""
+        # Both return 'normal' phenotype — no tumor found
+        mock_get_library.side_effect = [
+            make_library_metadata("L2401001", "normal"),
+            make_library_metadata("L2401002", "normal"),
+        ]
+
+        event = event_builder({
+            "libraries": [
+                make_library_with_readsets("L2401001", "lib.abc1", ["RGID1"]),
+                make_library_with_readsets("L2401002", "lib.abc2", ["RGID2"]),
+            ]
+        })
+        ctx = lambda_context()
+
+        with pytest.raises(ValueError, match="No tumor library found"):
+            handler(event, ctx)
+
+    @patch("get_libraries.get_library_from_library_orcabus_id")
+    def test_missing_normal_raises_error(
+        self, mock_get_library, event_builder, lambda_context
+    ):
+        """If no normal library is found in the pair, raise ValueError."""
+        # Both return 'tumor' phenotype — no normal found
+        mock_get_library.side_effect = [
+            make_library_metadata("L2401001", "tumor"),
+            make_library_metadata("L2401002", "tumor"),
+        ]
+
+        event = event_builder({
+            "libraries": [
+                make_library_with_readsets("L2401001", "lib.abc1", ["RGID1"]),
+                make_library_with_readsets("L2401002", "lib.abc2", ["RGID2"]),
+            ]
+        })
+        ctx = lambda_context()
+
+        with pytest.raises(ValueError, match="No normal library found"):
+            handler(event, ctx)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Input validation
+# ---------------------------------------------------------------------------
+
+
+class TestInputValidation:
+    """Test handler behaviour with invalid inputs."""
+
+    def test_empty_libraries_raises_error(self, event_builder, lambda_context):
+        """An empty libraries list raises ValueError."""
+        event = event_builder({"libraries": []})
+        ctx = lambda_context()
+
+        with pytest.raises(ValueError, match="No libraries provided"):
+            handler(event, ctx)
+
+    def test_too_many_libraries_raises_error(self, event_builder, lambda_context):
+        """More than two libraries raises ValueError."""
+        event = event_builder({
+            "libraries": [
+                make_library_with_readsets(f"L240100{i}", f"lib.abc{i}", [f"RGID{i}"])
+                for i in range(3)
+            ]
+        })
+        ctx = lambda_context()
+
+        with pytest.raises(ValueError, match="at most two libraries"):
+            handler(event, ctx)

--- a/app/lambdas/tests/examples/test_data_transformation_example.py
+++ b/app/lambdas/tests/examples/test_data_transformation_example.py
@@ -1,0 +1,187 @@
+"""
+Example: Testing a Pure Data Transformation Lambda
+===================================================
+
+This template demonstrates how to test a Lambda function that performs
+pure input/output transformations — no external service calls, no AWS SDK
+usage. These are the simplest Lambdas to test because they are
+deterministic functions of their inputs.
+
+Pattern:
+    - Call handler(event, context) with known inputs
+    - Assert the output matches expected values
+    - Test edge cases (boundary values, empty inputs, invalid inputs)
+
+Real-world example: calculate_downsampling_ratios_py
+    - Takes coverage and duplication estimates
+    - Returns downsampling ratios based on business logic
+    - No AWS API calls — pure computation
+
+Fixtures used:
+    - event_builder: Wraps a dict payload into a Lambda event
+    - lambda_context: Provides a mock Lambda context object
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup: add the Lambda source directory to sys.path so the handler
+# can be imported directly without packaging.
+# ---------------------------------------------------------------------------
+LAMBDA_DIR = Path(__file__).resolve().parents[2] / "calculate_downsampling_ratios_py"
+sys.path.insert(0, str(LAMBDA_DIR))
+
+from calculate_downsampling_ratios import handler  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestDataTransformationHappyPath:
+    """Test the happy path where the ratio falls within acceptable bounds."""
+
+    def test_ratio_within_bounds_returns_none(self, event_builder, lambda_context):
+        """When the tumor/normal ratio is between 1 and 3, no downsampling is needed."""
+        # Arrange: Set coverage so ratio = 2.0 (within [1, 3])
+        event = event_builder({
+            "normalCoverageEst": 30.0,
+            "tumorCoverageEst": 60.0,
+            "normalDupFracEst": 0.0,
+            "tumorDupFracEst": 0.0,
+        })
+        ctx = lambda_context(function_name="calculate-downsampling-ratios")
+
+        # Act
+        result = handler(event, ctx)
+
+        # Assert: No downsampling needed
+        assert result is None
+
+    def test_ratio_exactly_one_returns_none(self, event_builder, lambda_context):
+        """Boundary: ratio exactly 1.0 should not trigger downsampling."""
+        event = event_builder({
+            "normalCoverageEst": 50.0,
+            "tumorCoverageEst": 50.0,
+            "normalDupFracEst": 0.1,
+            "tumorDupFracEst": 0.1,
+        })
+        ctx = lambda_context()
+
+        result = handler(event, ctx)
+
+        assert result is None
+
+    def test_ratio_exactly_three_returns_none(self, event_builder, lambda_context):
+        """Boundary: ratio exactly 3.0 should not trigger downsampling."""
+        event = event_builder({
+            "normalCoverageEst": 30.0,
+            "tumorCoverageEst": 90.0,
+            "normalDupFracEst": 0.0,
+            "tumorDupFracEst": 0.0,
+        })
+        ctx = lambda_context()
+
+        result = handler(event, ctx)
+
+        assert result is None
+
+
+class TestDataTransformationDownsampling:
+    """Test cases where downsampling IS required."""
+
+    def test_high_ratio_downsamples_tumor(self, event_builder, lambda_context):
+        """When ratio > 3, tumor should be downsampled."""
+        # ratio = 6.0 (> MAX_RATIO of 3)
+        event = event_builder({
+            "normalCoverageEst": 30.0,
+            "tumorCoverageEst": 180.0,
+            "normalDupFracEst": 0.0,
+            "tumorDupFracEst": 0.0,
+        })
+        ctx = lambda_context()
+
+        result = handler(event, ctx)
+
+        assert result is not None
+        assert result["enableFractionalDownSampler"] is True
+        assert "downSamplerTumorSubsample" in result
+        # 3/6 = 0.5
+        assert result["downSamplerTumorSubsample"] == 0.5
+
+    def test_low_ratio_downsamples_normal(self, event_builder, lambda_context):
+        """When ratio < 1, normal should be downsampled."""
+        # ratio = 0.5 (< MIN_RATIO of 1)
+        event = event_builder({
+            "normalCoverageEst": 100.0,
+            "tumorCoverageEst": 50.0,
+            "normalDupFracEst": 0.0,
+            "tumorDupFracEst": 0.0,
+        })
+        ctx = lambda_context()
+
+        result = handler(event, ctx)
+
+        assert result is not None
+        assert result["enableFractionalDownSampler"] is True
+        assert "downSamplerNormalSubsample" in result
+        # 0.5 / 1 = 0.5
+        assert result["downSamplerNormalSubsample"] == 0.5
+
+
+class TestDataTransformationEdgeCases:
+    """Test edge cases and invalid inputs."""
+
+    def test_zero_normal_coverage_raises_error(self, event_builder, lambda_context):
+        """Invalid input: zero coverage should raise ValueError."""
+        event = event_builder({
+            "normalCoverageEst": 0.0,
+            "tumorCoverageEst": 50.0,
+            "normalDupFracEst": 0.0,
+            "tumorDupFracEst": 0.0,
+        })
+        ctx = lambda_context()
+
+        with pytest.raises(ValueError, match="normalCoverageEst must be > 0"):
+            handler(event, ctx)
+
+    def test_negative_coverage_raises_error(self, event_builder, lambda_context):
+        """Invalid input: negative coverage (QC unavailable) should raise ValueError."""
+        event = event_builder({
+            "normalCoverageEst": -1.0,
+            "tumorCoverageEst": 50.0,
+            "normalDupFracEst": 0.0,
+            "tumorDupFracEst": 0.0,
+        })
+        ctx = lambda_context()
+
+        with pytest.raises(ValueError, match="normalCoverageEst must be > 0"):
+            handler(event, ctx)
+
+    def test_dup_frac_one_raises_error(self, event_builder, lambda_context):
+        """Invalid input: duplication fraction of 1.0 would cause division by zero."""
+        event = event_builder({
+            "normalCoverageEst": 50.0,
+            "tumorCoverageEst": 50.0,
+            "normalDupFracEst": 1.0,
+            "tumorDupFracEst": 0.0,
+        })
+        ctx = lambda_context()
+
+        with pytest.raises(ValueError, match="normalDupFracEst must be in"):
+            handler(event, ctx)
+
+    def test_missing_key_raises_key_error(self, event_builder, lambda_context):
+        """Missing required input field raises KeyError."""
+        event = event_builder({
+            "normalCoverageEst": 50.0,
+            # Missing tumorCoverageEst and other fields
+        })
+        ctx = lambda_context()
+
+        with pytest.raises(KeyError):
+            handler(event, ctx)

--- a/app/lambdas/tests/examples/test_validation_example.py
+++ b/app/lambdas/tests/examples/test_validation_example.py
@@ -1,0 +1,371 @@
+"""
+Example: Testing a Schema Validation Lambda
+============================================
+
+This template demonstrates how to test a Lambda function that validates
+input data against a JSON schema. The Lambda fetches its schema from AWS
+services (SSM + Schemas Registry) at runtime, so we patch those data-fetching
+functions to inject a known schema for testing.
+
+Pattern:
+    - Patch functions that fetch configuration from AWS (SSM, Schema Registry)
+    - Provide a test JSON schema inline
+    - Call handler with valid data → assert isValid=True
+    - Call handler with invalid data → assert isValid=False
+    - Test specific validation failures (missing fields, wrong types)
+
+Real-world example: validate_draft_complete_schema_py
+    - Fetches schema registry name from SSM
+    - Fetches schema from AWS Schemas Registry
+    - Validates event payload against the JSON schema
+    - Returns {"isValid": true/false}
+
+Fixtures used:
+    - event_builder: Wraps a dict payload into a Lambda event
+    - lambda_context: Provides a mock Lambda context object
+
+Note: Since moto does not fully support the AWS Schemas Registry service,
+we patch the individual helper functions (get_ssm_parameter_value,
+get_schema_from_registry) rather than mocking the entire AWS service.
+This approach is simpler and more resilient to moto version changes.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup
+#
+# The validate_draft_complete_schema Lambda uses the `orcabus_api_tools`
+# layer package. We mock it before importing the handler.
+# ---------------------------------------------------------------------------
+LAMBDA_DIR = (
+    Path(__file__).resolve().parents[2] / "validate_draft_complete_schema_py"
+)
+
+# Mock the Lambda Layer dependency (orcabus_api_tools)
+_mock_api_tools = MagicMock()
+sys.modules.setdefault("orcabus_api_tools", _mock_api_tools)
+sys.modules.setdefault("orcabus_api_tools.workflow", _mock_api_tools.workflow)
+
+sys.path.insert(0, str(LAMBDA_DIR))
+
+from validate_draft_complete_schema import handler  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Test JSON Schema — a simplified version of the real draft schema
+# ---------------------------------------------------------------------------
+
+SAMPLE_SCHEMA = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "required": ["sampleId", "libraryId", "fastqListRows"],
+    "properties": {
+        "sampleId": {"type": "string", "minLength": 1},
+        "libraryId": {"type": "string", "minLength": 1},
+        "fastqListRows": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "object",
+                "required": ["rgid", "rgsm", "lane", "read1FileUri"],
+                "properties": {
+                    "rgid": {"type": "string"},
+                    "rgsm": {"type": "string"},
+                    "lane": {"type": "integer", "minimum": 1},
+                    "read1FileUri": {
+                        "type": "string",
+                        "pattern": "^s3://",
+                    },
+                },
+            },
+        },
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures specific to this test module
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _set_env_vars():
+    """Set required environment variables for the Lambda."""
+    env_vars = {
+        "SSM_REGISTRY_NAME": "/orcabus/schemas/registry-name",
+        "SSM_SCHEMA_PATH": "/orcabus/workflows/dragen-wgts-dna/schema",
+        "WORKFLOW_NAME": "dragen-wgts-dna",
+        "DEFAULT_PAYLOAD_VERSION": "2025.08.05",
+    }
+    with patch.dict(os.environ, env_vars):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _mock_aws_calls():
+    """Patch the AWS service calls to return controlled test data.
+
+    This patches:
+    - get_ssm_parameter_value → returns registry name or schema name JSON
+    - get_schema_from_registry → returns our test schema
+    - add_comment_to_workflow_run → no-op (we test it was called separately)
+    """
+    def ssm_side_effect(parameter_name: str) -> str:
+        """Simulate SSM parameter lookups."""
+        params = {
+            "/orcabus/schemas/registry-name": "OrcaBusSchemaRegistry",
+            "/orcabus/workflows/dragen-wgts-dna/schema/2025.08.05": json.dumps(
+                {"schemaName": "dragen-wgts-dna-draft-v2025.08.05"}
+            ),
+        }
+        if parameter_name in params:
+            return params[parameter_name]
+        raise ValueError(f"Unknown SSM parameter: {parameter_name}")
+
+    with (
+        patch(
+            "validate_draft_complete_schema.get_ssm_parameter_value",
+            side_effect=ssm_side_effect,
+        ),
+        patch(
+            "validate_draft_complete_schema.get_schema_from_registry",
+            return_value=json.dumps(SAMPLE_SCHEMA),
+        ),
+        patch(
+            "validate_draft_complete_schema.add_comment_to_workflow_run",
+        ) as mock_comment,
+    ):
+        yield mock_comment
+
+
+# ---------------------------------------------------------------------------
+# Tests: Valid inputs
+# ---------------------------------------------------------------------------
+
+
+class TestValidPayloads:
+    """Test that valid payloads pass schema validation."""
+
+    def test_valid_minimal_payload(self, event_builder, lambda_context):
+        """A payload with all required fields passes validation."""
+        event = event_builder({
+            "payloadVersion": "2025.08.05",
+            "data": {
+                "sampleId": "SMP001",
+                "libraryId": "L2401001",
+                "fastqListRows": [
+                    {
+                        "rgid": "RGID001.1.AACTGAGG.AACTGAGG",
+                        "rgsm": "SMP001",
+                        "lane": 1,
+                        "read1FileUri": "s3://bucket/path/read1.fastq.gz",
+                    }
+                ],
+            },
+        })
+        ctx = lambda_context(function_name="validate-draft-complete-schema")
+
+        result = handler(event, ctx)
+
+        assert result["isValid"] is True
+
+    def test_valid_payload_multiple_fastq_rows(self, event_builder, lambda_context):
+        """A payload with multiple FASTQ rows passes validation."""
+        event = event_builder({
+            "payloadVersion": "2025.08.05",
+            "data": {
+                "sampleId": "SMP001",
+                "libraryId": "L2401001",
+                "fastqListRows": [
+                    {
+                        "rgid": "RGID001.1.AACTGAGG",
+                        "rgsm": "SMP001",
+                        "lane": 1,
+                        "read1FileUri": "s3://bucket/lane1/read1.fastq.gz",
+                    },
+                    {
+                        "rgid": "RGID001.2.AACTGAGG",
+                        "rgsm": "SMP001",
+                        "lane": 2,
+                        "read1FileUri": "s3://bucket/lane2/read1.fastq.gz",
+                    },
+                ],
+            },
+        })
+        ctx = lambda_context()
+
+        result = handler(event, ctx)
+
+        assert result["isValid"] is True
+
+
+# ---------------------------------------------------------------------------
+# Tests: Invalid inputs
+# ---------------------------------------------------------------------------
+
+
+class TestInvalidPayloads:
+    """Test that invalid payloads fail schema validation with isValid=False."""
+
+    def test_missing_required_field(self, event_builder, lambda_context):
+        """A payload missing 'sampleId' fails validation."""
+        event = event_builder({
+            "payloadVersion": "2025.08.05",
+            "data": {
+                # Missing sampleId
+                "libraryId": "L2401001",
+                "fastqListRows": [
+                    {
+                        "rgid": "RGID001",
+                        "rgsm": "SMP001",
+                        "lane": 1,
+                        "read1FileUri": "s3://bucket/read1.fastq.gz",
+                    }
+                ],
+            },
+        })
+        ctx = lambda_context()
+
+        result = handler(event, ctx)
+
+        assert result["isValid"] is False
+
+    def test_wrong_type_for_field(self, event_builder, lambda_context):
+        """A payload with wrong type for 'lane' (string instead of integer) fails."""
+        event = event_builder({
+            "payloadVersion": "2025.08.05",
+            "data": {
+                "sampleId": "SMP001",
+                "libraryId": "L2401001",
+                "fastqListRows": [
+                    {
+                        "rgid": "RGID001",
+                        "rgsm": "SMP001",
+                        "lane": "one",  # Should be an integer
+                        "read1FileUri": "s3://bucket/read1.fastq.gz",
+                    }
+                ],
+            },
+        })
+        ctx = lambda_context()
+
+        result = handler(event, ctx)
+
+        assert result["isValid"] is False
+
+    def test_empty_fastq_list_rows(self, event_builder, lambda_context):
+        """A payload with an empty fastqListRows array fails minItems validation."""
+        event = event_builder({
+            "payloadVersion": "2025.08.05",
+            "data": {
+                "sampleId": "SMP001",
+                "libraryId": "L2401001",
+                "fastqListRows": [],  # Must have at least 1 item
+            },
+        })
+        ctx = lambda_context()
+
+        result = handler(event, ctx)
+
+        assert result["isValid"] is False
+
+    def test_invalid_uri_pattern(self, event_builder, lambda_context):
+        """A read1FileUri that doesn't start with s3:// fails pattern validation."""
+        event = event_builder({
+            "payloadVersion": "2025.08.05",
+            "data": {
+                "sampleId": "SMP001",
+                "libraryId": "L2401001",
+                "fastqListRows": [
+                    {
+                        "rgid": "RGID001",
+                        "rgsm": "SMP001",
+                        "lane": 1,
+                        "read1FileUri": "https://bucket/read1.fastq.gz",  # Not s3://
+                    }
+                ],
+            },
+        })
+        ctx = lambda_context()
+
+        result = handler(event, ctx)
+
+        assert result["isValid"] is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: Error comment behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestErrorCommentBehaviour:
+    """Test that validation failure comments are posted when requested."""
+
+    def test_comment_added_on_error_when_flag_set(
+        self, _mock_aws_calls, event_builder, lambda_context
+    ):
+        """When addCommentOnError=True and validation fails, a comment is posted."""
+        mock_comment = _mock_aws_calls
+
+        event = event_builder({
+            "payloadVersion": "2025.08.05",
+            "workflowRunId": "wfr.abc123",
+            "addCommentOnError": True,
+            "data": {
+                # Missing sampleId to trigger validation failure
+                "libraryId": "L2401001",
+                "fastqListRows": [
+                    {
+                        "rgid": "RGID001",
+                        "rgsm": "SMP001",
+                        "lane": 1,
+                        "read1FileUri": "s3://bucket/read1.fastq.gz",
+                    }
+                ],
+            },
+        })
+        ctx = lambda_context()
+
+        result = handler(event, ctx)
+
+        assert result["isValid"] is False
+        # Verify the comment API was called with the workflow run ID
+        mock_comment.assert_called_once()
+        call_kwargs = mock_comment.call_args
+        assert "wfr.abc123" in str(call_kwargs)
+
+    def test_no_comment_when_flag_not_set(
+        self, _mock_aws_calls, event_builder, lambda_context
+    ):
+        """When addCommentOnError is False (default), no comment is posted on failure."""
+        mock_comment = _mock_aws_calls
+
+        event = event_builder({
+            "payloadVersion": "2025.08.05",
+            "data": {
+                # Missing sampleId to trigger validation failure
+                "libraryId": "L2401001",
+                "fastqListRows": [
+                    {
+                        "rgid": "RGID001",
+                        "rgsm": "SMP001",
+                        "lane": 1,
+                        "read1FileUri": "s3://bucket/read1.fastq.gz",
+                    }
+                ],
+            },
+        })
+        ctx = lambda_context()
+
+        result = handler(event, ctx)
+
+        assert result["isValid"] is False
+        mock_comment.assert_not_called()

--- a/app/lambdas/tests/test_add_populate_draft_comment.py
+++ b/app/lambdas/tests/test_add_populate_draft_comment.py
@@ -1,0 +1,180 @@
+"""Tests for add_populate_draft_comment Lambda function.
+
+This Lambda adds a comment to a workflow run indicating the current
+populate-draft-data stage. It uses the orcabus_api_tools layer to post
+comments, which we mock here.
+"""
+
+import os
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup — mock the orcabus_api_tools layer before importing handler
+# ---------------------------------------------------------------------------
+LAMBDA_DIR = Path(__file__).resolve().parents[1] / "add_populate_draft_comment_py"
+
+_mock_api_tools = ModuleType("orcabus_api_tools")
+_mock_workflow = ModuleType("orcabus_api_tools.workflow")
+_mock_workflow.add_comment_to_workflow_run = MagicMock()
+_mock_api_tools.workflow = _mock_workflow
+
+sys.modules["orcabus_api_tools"] = _mock_api_tools
+sys.modules["orcabus_api_tools.workflow"] = _mock_workflow
+
+sys.path.insert(0, str(LAMBDA_DIR))
+
+from add_populate_draft_comment import handler  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _set_env_vars():
+    """Set required environment variables for the Lambda."""
+    env_vars = {
+        "WORKFLOW_NAME": "dragen-wgts-dna",
+        "REPOSITORY_GITHUB_URL": "https://github.com/umccr/orcabus",
+    }
+    with patch.dict(os.environ, env_vars):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _reset_mock():
+    """Reset the add_comment_to_workflow_run mock between tests."""
+    _mock_workflow.add_comment_to_workflow_run.reset_mock()
+    yield
+
+
+@pytest.mark.lambda_unit
+class TestAddPopulateDraftCommentHappyPath:
+    """Test the comment generation for various populate-draft stages."""
+
+    def test_tags_changed_comment(self, event_builder, lambda_context):
+        """commentType=tags_changed should post a tags-changed comment."""
+        event = event_builder({
+            "workflowRunId": "wfr.abc123",
+            "commentType": "tags_changed",
+            "executionArn": "arn:aws:states:ap-southeast-2:123456:execution:sfn:exec-1",
+        })
+
+        result = handler(event, lambda_context())
+
+        assert result == {"commentAdded": True}
+        _mock_workflow.add_comment_to_workflow_run.assert_called_once()
+        call_kwargs = _mock_workflow.add_comment_to_workflow_run.call_args[1]
+        assert call_kwargs["workflow_run_orcabus_id"] == "wfr.abc123"
+        assert "tags" in call_kwargs["comment"]
+
+    def test_engine_parameters_changed_comment(self, event_builder, lambda_context):
+        """commentType=engine_parameters_changed should mention engine parameters."""
+        event = event_builder({
+            "workflowRunId": "wfr.def456",
+            "commentType": "engine_parameters_changed",
+            "executionArn": "arn:aws:states:ap-southeast-2:123456:execution:sfn:exec-2",
+        })
+
+        result = handler(event, lambda_context())
+
+        assert result == {"commentAdded": True}
+        call_kwargs = _mock_workflow.add_comment_to_workflow_run.call_args[1]
+        assert "engine parameters" in call_kwargs["comment"]
+
+    def test_both_changed_comment(self, event_builder, lambda_context):
+        """commentType=both_changed should mention both tags and engine parameters."""
+        event = event_builder({
+            "workflowRunId": "wfr.ghi789",
+            "commentType": "both_changed",
+            "executionArn": "arn:aws:states:ap-southeast-2:123456:execution:sfn:exec-3",
+        })
+
+        result = handler(event, lambda_context())
+
+        assert result == {"commentAdded": True}
+        call_kwargs = _mock_workflow.add_comment_to_workflow_run.call_args[1]
+        assert "tags" in call_kwargs["comment"]
+        assert "engine parameters" in call_kwargs["comment"]
+
+    def test_updating_inputs_comment(self, event_builder, lambda_context):
+        """commentType=updating_inputs should mention updating inputs."""
+        event = event_builder({
+            "workflowRunId": "wfr.jkl012",
+            "commentType": "updating_inputs",
+            "executionArn": "arn:aws:states:ap-southeast-2:123456:execution:sfn:exec-4",
+        })
+
+        result = handler(event, lambda_context())
+
+        assert result == {"commentAdded": True}
+        call_kwargs = _mock_workflow.add_comment_to_workflow_run.call_args[1]
+        assert "inputs" in call_kwargs["comment"].lower()
+
+    def test_no_change_missing_fields_comment(self, event_builder, lambda_context):
+        """commentType=no_change_missing_fields should list missing fields."""
+        event = event_builder({
+            "workflowRunId": "wfr.mno345",
+            "commentType": "no_change_missing_fields",
+            "missingFields": ["inputs.sequenceData", "inputs.reference.tarball"],
+            "executionArn": "arn:aws:states:ap-southeast-2:123456:execution:sfn:exec-5",
+        })
+
+        result = handler(event, lambda_context())
+
+        assert result == {"commentAdded": True}
+        call_kwargs = _mock_workflow.add_comment_to_workflow_run.call_args[1]
+        assert "inputs.sequenceData" in call_kwargs["comment"]
+        assert "inputs.reference.tarball" in call_kwargs["comment"]
+
+
+@pytest.mark.lambda_unit
+class TestAddPopulateDraftCommentAuthor:
+    """Test that the comment author is constructed correctly."""
+
+    def test_author_contains_workflow_name(self, event_builder, lambda_context):
+        """Author string should contain the workflow name."""
+        event = event_builder({
+            "workflowRunId": "wfr.test",
+            "commentType": "updating_inputs",
+            "executionArn": "arn:aws:states:ap-southeast-2:123456:execution:sfn:exec",
+        })
+
+        handler(event, lambda_context())
+
+        call_kwargs = _mock_workflow.add_comment_to_workflow_run.call_args[1]
+        assert "dragen-wgts-dna" in call_kwargs["author"]
+
+
+@pytest.mark.lambda_unit
+class TestAddPopulateDraftCommentFooter:
+    """Test that the execution ARN footer is appended."""
+
+    def test_execution_arn_in_comment(self, event_builder, lambda_context):
+        """The execution ARN should appear in the comment footer."""
+        arn = "arn:aws:states:ap-southeast-2:123456:execution:sfn:my-exec"
+        event = event_builder({
+            "workflowRunId": "wfr.footer",
+            "commentType": "tags_changed",
+            "executionArn": arn,
+        })
+
+        handler(event, lambda_context())
+
+        call_kwargs = _mock_workflow.add_comment_to_workflow_run.call_args[1]
+        assert arn in call_kwargs["comment"]
+
+    def test_long_comment_truncated(self, event_builder, lambda_context):
+        """Comments exceeding 1024 chars should be truncated."""
+        event = event_builder({
+            "workflowRunId": "wfr.truncate",
+            "commentType": "no_change_missing_fields",
+            "missingFields": [f"inputs.field_{i}" for i in range(100)],
+            "executionArn": "arn:aws:states:ap-southeast-2:123456:execution:sfn:long-exec",
+        })
+
+        handler(event, lambda_context())
+
+        call_kwargs = _mock_workflow.add_comment_to_workflow_run.call_args[1]
+        assert len(call_kwargs["comment"]) <= 1024

--- a/app/lambdas/tests/test_add_post_analysis_tags.py
+++ b/app/lambdas/tests/test_add_post_analysis_tags.py
@@ -1,0 +1,252 @@
+"""Tests for add_post_analysis_tags Lambda function.
+
+This Lambda collects post-analysis QC metrics from S3 output files (CSVs, JSON)
+and returns them as camelCase tags. It uses orcabus_api_tools.filemanager for
+S3 file access, which we mock here.
+"""
+
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup — mock the orcabus_api_tools layer and pandas dependency
+# ---------------------------------------------------------------------------
+LAMBDA_DIR = Path(__file__).resolve().parents[1] / "add_post_analysis_tags_py"
+
+_mock_api_tools = ModuleType("orcabus_api_tools")
+_mock_filemanager = ModuleType("orcabus_api_tools.filemanager")
+_mock_filemanager.get_presigned_url = MagicMock()
+_mock_filemanager.get_file_object_from_s3_uri = MagicMock()
+_mock_filemanager_errors = ModuleType("orcabus_api_tools.filemanager.errors")
+_mock_filemanager_errors.S3FileNotFoundError = type("S3FileNotFoundError", (Exception,), {})
+_mock_filemanager.errors = _mock_filemanager_errors
+_mock_api_tools.filemanager = _mock_filemanager
+
+sys.modules["orcabus_api_tools"] = _mock_api_tools
+sys.modules["orcabus_api_tools.filemanager"] = _mock_filemanager
+sys.modules["orcabus_api_tools.filemanager.errors"] = _mock_filemanager_errors
+
+sys.path.insert(0, str(LAMBDA_DIR))
+
+from add_post_analysis_tags import handler, snake_to_camel  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_mocks():
+    """Reset filemanager mocks between tests."""
+    _mock_filemanager.get_presigned_url.reset_mock()
+    _mock_filemanager.get_file_object_from_s3_uri.reset_mock()
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Tests: snake_to_camel utility
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.lambda_unit
+class TestSnakeToCamel:
+    """Test the snake_to_camel utility function."""
+
+    def test_single_word(self):
+        assert snake_to_camel("hello") == "hello"
+
+    def test_two_words(self):
+        assert snake_to_camel("hello_world") == "helloWorld"
+
+    def test_multi_word(self):
+        assert snake_to_camel("avg_autosomal_coverage_over_genome") == "avgAutosomalCoverageOverGenome"
+
+    def test_with_tumor_prefix(self):
+        assert snake_to_camel("tumor_hrd_score") == "tumorHrdScore"
+
+
+# ---------------------------------------------------------------------------
+# Tests: Handler with mocked S3 reads
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.lambda_unit
+class TestAddPostAnalysisTagsNormal:
+    """Test tags returned for a normal (non-tumor) sample."""
+
+    @patch("add_post_analysis_tags.read_json_from_s3")
+    @patch("add_post_analysis_tags.read_csv_from_s3")
+    def test_normal_sample_returns_expected_keys(
+        self, mock_read_csv, mock_read_json, event_builder, lambda_context
+    ):
+        """A normal sample should return coverage, contamination, dup, variants, tiTv."""
+        import pandas as pd
+
+        # Mock coverage CSV
+        mock_read_csv.return_value = pd.DataFrame([
+            {"summary": "COVERAGE SUMMARY", "region": "", "metric": "Average autosomal coverage over genome", "value": 82.16, "pct": None}
+        ])
+
+        # Mock metrics JSON
+        mock_read_json.return_value = {
+            "modules": {
+                "mapAlign": {
+                    "globalMetrics": {
+                        "estimatedSampleContamination": {"value": 0.001},
+                        "duplicateMarkedReads": {"percentage": 12.5},
+                    }
+                },
+                "variantCaller": {
+                    "postFilter": {
+                        "SAMPLE001": {
+                            "totalVariants": {"value": 4500000},
+                            "tiTvRatio": {"value": 2.05},
+                        }
+                    }
+                },
+            }
+        }
+
+        event = event_builder({
+            "variantCallingSampleName": "SAMPLE001",
+            "variantCallingOutputUri": "s3://bucket/output/",
+            "isTumor": False,
+        })
+
+        result = handler(event, lambda_context())
+
+        assert "tags" in result
+        tags = result["tags"]
+        # Normal sample should NOT have tumor-specific keys
+        assert "tumorHrdScore" not in tags
+        assert "tumorTmbScore" not in tags
+        # Should have these keys
+        assert "avgAutosomalCoverageOverGenome" in tags
+        assert "contaminationRate" in tags
+        assert "duplicationFrac" in tags
+        assert "totalPostFilterVariants" in tags
+        assert "tiTvRatio" in tags
+
+    @patch("add_post_analysis_tags.read_json_from_s3")
+    @patch("add_post_analysis_tags.read_csv_from_s3")
+    def test_none_values_are_dropped(
+        self, mock_read_csv, mock_read_json, event_builder, lambda_context
+    ):
+        """Tags with None values should be excluded from the output."""
+        mock_read_csv.return_value = None
+        mock_read_json.return_value = None
+
+        event = event_builder({
+            "variantCallingSampleName": "SAMPLE001",
+            "variantCallingOutputUri": "s3://bucket/output/",
+            "isTumor": False,
+        })
+
+        result = handler(event, lambda_context())
+
+        assert result == {"tags": {}}
+
+
+@pytest.mark.lambda_unit
+class TestAddPostAnalysisTagsTumor:
+    """Test tags returned for a tumor sample."""
+
+    @patch("add_post_analysis_tags.read_json_from_s3")
+    @patch("add_post_analysis_tags.read_csv_from_s3")
+    def test_tumor_sample_keys_prefixed(
+        self, mock_read_csv, mock_read_json, event_builder, lambda_context
+    ):
+        """Tumor sample tags should be prefixed with 'tumor' in camelCase."""
+        import pandas as pd
+
+        # Each call to read_csv returns a different DF based on which file is read
+        def csv_side_effect(uri, **kwargs):
+            if "hrdscore" in uri:
+                return pd.DataFrame([{"Sample": "TUMOR001", "HRD_Score": 45}])
+            if "tmb.metrics" in uri:
+                return pd.DataFrame([{"summary": "s", "null": None, "metric": "TMB", "value": 8.5}])
+            if "sv_metrics" in uri:
+                return pd.DataFrame([{
+                    "summary": "SV SUMMARY", "sample": "TUMOR001",
+                    "metric": "Total number of structural variants (PASS)", "value": 753, "pct": None
+                }])
+            if "cnv_metrics" in uri:
+                return pd.DataFrame([
+                    {"summary": "CNV SUMMARY", "sample": "", "metric": "Estimated tumor purity", "value": 0.60, "pct": None},
+                    {"summary": "CNV SUMMARY", "sample": "", "metric": "Overall ploidy", "value": 2.06, "pct": None},
+                ])
+            if "wgs_coverage_metrics_tumor" in uri:
+                return pd.DataFrame([{
+                    "summary": "COVERAGE SUMMARY", "region": "", "metric": "Average autosomal coverage over genome",
+                    "value": 74.43, "pct": None
+                }])
+            return None
+
+        mock_read_csv.side_effect = csv_side_effect
+
+        mock_read_json.return_value = {
+            "modules": {
+                "mapAlign": {
+                    "globalMetrics": {
+                        "estimatedSampleContamination": {"value": 0.002},
+                        "duplicateMarkedReads": {"percentage": 14.39},
+                    }
+                },
+                "variantCaller": {
+                    "postFilter": {
+                        "TUMOR001": {
+                            "totalVariants": {"value": 55000},
+                            "tiTvRatio": {"value": 1.8},
+                        }
+                    }
+                },
+            }
+        }
+
+        event = event_builder({
+            "variantCallingSampleName": "TUMOR001",
+            "variantCallingOutputUri": "s3://bucket/output/",
+            "isTumor": True,
+        })
+
+        result = handler(event, lambda_context())
+
+        tags = result["tags"]
+        # Tumor keys should be prefixed
+        assert "tumorHrdScore" in tags
+        assert tags["tumorHrdScore"] == 45
+        assert "tumorTmbScore" in tags
+        assert "tumorSvPassCount" in tags
+        assert "tumorCnvEstimatedTumorPurity" in tags
+        assert "tumorCnvOverallPloidy" in tags
+        assert "tumorAvgAutosomalCoverageOverGenome" in tags
+        assert "tumorContaminationRate" in tags
+        assert "tumorDuplicationFrac" in tags
+
+
+@pytest.mark.lambda_unit
+class TestAddPostAnalysisTagsInputValidation:
+    """Test error handling for missing inputs."""
+
+    def test_missing_sample_name_raises(self, event_builder, lambda_context):
+        """Missing variantCallingSampleName should raise ValueError."""
+        event = event_builder({
+            "variantCallingOutputUri": "s3://bucket/output/",
+        })
+
+        with pytest.raises(ValueError, match="Missing required inputs"):
+            handler(event, lambda_context())
+
+    def test_missing_output_uri_raises(self, event_builder, lambda_context):
+        """Missing variantCallingOutputUri should raise ValueError."""
+        event = event_builder({
+            "variantCallingSampleName": "SAMPLE001",
+        })
+
+        with pytest.raises(ValueError, match="Missing required inputs"):
+            handler(event, lambda_context())

--- a/app/lambdas/tests/test_add_ready_comment.py
+++ b/app/lambdas/tests/test_add_ready_comment.py
@@ -1,0 +1,128 @@
+t"""Tests for add_ready_comment Lambda function.
+
+This Lambda adds a comment to a workflow run indicating the READY-to-SUBMITTED
+transition has started. It uses the orcabus_api_tools layer to post comments.
+"""
+
+import os
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup — mock the orcabus_api_tools layer before importing handler
+# ---------------------------------------------------------------------------
+LAMBDA_DIR = Path(__file__).resolve().parents[1] / "add_ready_comment_py"
+
+_mock_api_tools = ModuleType("orcabus_api_tools")
+_mock_workflow = ModuleType("orcabus_api_tools.workflow")
+_mock_workflow.add_comment_to_workflow_run = MagicMock()
+_mock_api_tools.workflow = _mock_workflow
+
+sys.modules["orcabus_api_tools"] = _mock_api_tools
+sys.modules["orcabus_api_tools.workflow"] = _mock_workflow
+
+sys.path.insert(0, str(LAMBDA_DIR))
+
+from add_ready_comment import handler  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _set_env_vars():
+    """Set required environment variables for the Lambda."""
+    with patch.dict(os.environ, {"WORKFLOW_NAME": "dragen-wgts-dna"}):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _reset_mock():
+    """Reset the add_comment_to_workflow_run mock between tests."""
+    _mock_workflow.add_comment_to_workflow_run.reset_mock()
+    yield
+
+
+@pytest.mark.lambda_unit
+class TestAddReadyCommentHappyPath:
+    """Test the happy-path comment generation."""
+
+    def test_returns_comment_added_true(self, event_builder, lambda_context):
+        """Handler should return commentAdded=True on success."""
+        event = event_builder({
+            "workflowRunId": "wfr.ready123",
+            "executionArn": "arn:aws:states:ap-southeast-2:123456:execution:sfn:exec-1",
+        })
+
+        result = handler(event, lambda_context())
+
+        assert result == {"commentAdded": True}
+
+    def test_comment_mentions_ready_to_submitted(self, event_builder, lambda_context):
+        """Comment body should mention the READY-to-SUBMITTED transition."""
+        event = event_builder({
+            "workflowRunId": "wfr.ready456",
+            "executionArn": "arn:aws:states:ap-southeast-2:123456:execution:sfn:exec-2",
+        })
+
+        handler(event, lambda_context())
+
+        call_kwargs = _mock_workflow.add_comment_to_workflow_run.call_args[1]
+        assert "READY" in call_kwargs["comment"]
+        assert "SUBMITTED" in call_kwargs["comment"]
+
+    def test_workflow_run_id_passed_correctly(self, event_builder, lambda_context):
+        """The workflow_run_orcabus_id should match the input workflowRunId."""
+        event = event_builder({
+            "workflowRunId": "wfr.specific789",
+            "executionArn": "arn:aws:states:ap-southeast-2:123456:execution:sfn:exec-3",
+        })
+
+        handler(event, lambda_context())
+
+        call_kwargs = _mock_workflow.add_comment_to_workflow_run.call_args[1]
+        assert call_kwargs["workflow_run_orcabus_id"] == "wfr.specific789"
+
+    def test_execution_arn_in_footer(self, event_builder, lambda_context):
+        """The execution ARN should appear in the comment."""
+        arn = "arn:aws:states:ap-southeast-2:123456:execution:sfn:my-exec"
+        event = event_builder({
+            "workflowRunId": "wfr.footer",
+            "executionArn": arn,
+        })
+
+        handler(event, lambda_context())
+
+        call_kwargs = _mock_workflow.add_comment_to_workflow_run.call_args[1]
+        assert arn in call_kwargs["comment"]
+
+    def test_author_contains_workflow_name(self, event_builder, lambda_context):
+        """The comment author should contain the workflow name."""
+        event = event_builder({
+            "workflowRunId": "wfr.author",
+            "executionArn": "arn:aws:states:ap-southeast-2:123456:execution:sfn:exec",
+        })
+
+        handler(event, lambda_context())
+
+        call_kwargs = _mock_workflow.add_comment_to_workflow_run.call_args[1]
+        assert "dragen-wgts-dna" in call_kwargs["author"]
+
+
+@pytest.mark.lambda_unit
+class TestAddReadyCommentTruncation:
+    """Test comment truncation behaviour."""
+
+    def test_short_comment_not_truncated(self, event_builder, lambda_context):
+        """A normal comment should not be truncated."""
+        event = event_builder({
+            "workflowRunId": "wfr.short",
+            "executionArn": "arn:aws:states:ap-southeast-2:123456:execution:sfn:exec",
+        })
+
+        handler(event, lambda_context())
+
+        call_kwargs = _mock_workflow.add_comment_to_workflow_run.call_args[1]
+        assert len(call_kwargs["comment"]) <= 1024
+        assert "[truncated" not in call_kwargs["comment"]

--- a/app/lambdas/tests/test_add_wes_failure_comment.py
+++ b/app/lambdas/tests/test_add_wes_failure_comment.py
@@ -1,0 +1,165 @@
+"""Tests for add_wes_failure_comment Lambda function.
+
+This Lambda posts a comment to the workflow run when an ICA analysis has failed.
+It looks up the workflow run from the portal run ID, then posts a comment with
+the error type and error message URI.
+"""
+
+import os
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup — mock the orcabus_api_tools layer before importing handler
+# ---------------------------------------------------------------------------
+LAMBDA_DIR = Path(__file__).resolve().parents[1] / "add_wes_failure_comment_py"
+
+_mock_api_tools = ModuleType("orcabus_api_tools")
+_mock_workflow = ModuleType("orcabus_api_tools.workflow")
+_mock_workflow.add_comment_to_workflow_run = MagicMock()
+_mock_workflow.get_workflow_run_from_portal_run_id = MagicMock()
+_mock_api_tools.workflow = _mock_workflow
+
+sys.modules["orcabus_api_tools"] = _mock_api_tools
+sys.modules["orcabus_api_tools.workflow"] = _mock_workflow
+
+sys.path.insert(0, str(LAMBDA_DIR))
+
+from add_wes_failure_comment import handler  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _set_env_vars():
+    """Set required environment variables for the Lambda."""
+    with patch.dict(os.environ, {"WORKFLOW_NAME": "dragen-wgts-dna"}):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _reset_mocks():
+    """Reset mocks between tests."""
+    _mock_workflow.add_comment_to_workflow_run.reset_mock()
+    _mock_workflow.get_workflow_run_from_portal_run_id.reset_mock()
+    # Default return value for workflow run lookup
+    _mock_workflow.get_workflow_run_from_portal_run_id.return_value = {
+        "orcabusId": "wfr.resolved123",
+        "portalRunId": "20250601abcd1234",  # pragma: allowlist secret
+    }
+    yield
+
+
+@pytest.mark.lambda_unit
+class TestAddWesFailureCommentHappyPath:
+    """Test the failure comment generation."""
+
+    def test_returns_expected_structure(self, event_builder, lambda_context):
+        """Handler should return status, portalRunId, and workflowRunId."""
+        event = event_builder({
+            "errorType": "TaskFailed",
+            "errorMessageUri": "s3://bucket/errors/error.log",
+            "portalRunId": "20250601abcd1234",  # pragma: allowlist secret
+            "executionArn": "arn:aws:states:ap-southeast-2:123456:execution:sfn:exec-1",
+        })
+
+        result = handler(event, lambda_context())
+
+        assert result["status"] == "comment_added"
+        assert result["portalRunId"] == "20250601abcd1234"  # pragma: allowlist secret
+        assert result["workflowRunId"] == "wfr.resolved123"
+
+    def test_comment_contains_error_type(self, event_builder, lambda_context):
+        """The posted comment should mention the error type."""
+        event = event_builder({
+            "errorType": "AnalysisTimeout",
+            "errorMessageUri": "s3://bucket/errors/timeout.log",
+            "portalRunId": "20250601abcd1234",  # pragma: allowlist secret
+            "executionArn": "arn:aws:states:ap-southeast-2:123456:execution:sfn:exec-2",
+        })
+
+        handler(event, lambda_context())
+
+        call_kwargs = _mock_workflow.add_comment_to_workflow_run.call_args[1]
+        assert "AnalysisTimeout" in call_kwargs["comment"]
+
+    def test_comment_contains_error_message_uri(self, event_builder, lambda_context):
+        """The posted comment should mention the error message URI."""
+        error_uri = "s3://bucket/errors/my-error.log"
+        event = event_builder({
+            "errorType": "TaskFailed",
+            "errorMessageUri": error_uri,
+            "portalRunId": "20250601abcd1234",  # pragma: allowlist secret
+            "executionArn": "arn:aws:states:ap-southeast-2:123456:execution:sfn:exec-3",
+        })
+
+        handler(event, lambda_context())
+
+        call_kwargs = _mock_workflow.add_comment_to_workflow_run.call_args[1]
+        assert error_uri in call_kwargs["comment"]
+
+    def test_workflow_run_looked_up_by_portal_run_id(self, event_builder, lambda_context):
+        """The handler should look up the workflow run using the portal run ID."""
+        event = event_builder({
+            "errorType": "TaskFailed",
+            "errorMessageUri": "s3://bucket/errors/error.log",
+            "portalRunId": "20250601efgh5678",  # pragma: allowlist secret
+            "executionArn": "arn:aws:states:ap-southeast-2:123456:execution:sfn:exec-4",
+        })
+
+        handler(event, lambda_context())
+
+        _mock_workflow.get_workflow_run_from_portal_run_id.assert_called_once_with(
+            "20250601efgh5678"
+        )
+
+    def test_execution_arn_in_comment_footer(self, event_builder, lambda_context):
+        """The execution ARN should appear in the comment footer."""
+        arn = "arn:aws:states:ap-southeast-2:123456:execution:sfn:my-exec"
+        event = event_builder({
+            "errorType": "TaskFailed",
+            "errorMessageUri": "s3://bucket/errors/error.log",
+            "portalRunId": "20250601abcd1234",  # pragma: allowlist secret
+            "executionArn": arn,
+        })
+
+        handler(event, lambda_context())
+
+        call_kwargs = _mock_workflow.add_comment_to_workflow_run.call_args[1]
+        assert arn in call_kwargs["comment"]
+
+    def test_author_contains_workflow_name(self, event_builder, lambda_context):
+        """The comment author should contain the workflow name."""
+        event = event_builder({
+            "errorType": "TaskFailed",
+            "errorMessageUri": "s3://bucket/errors/error.log",
+            "portalRunId": "20250601abcd1234",  # pragma: allowlist secret
+            "executionArn": "arn:aws:states:ap-southeast-2:123456:execution:sfn:exec",
+        })
+
+        handler(event, lambda_context())
+
+        call_kwargs = _mock_workflow.add_comment_to_workflow_run.call_args[1]
+        assert "dragen-wgts-dna" in call_kwargs["author"]
+
+
+@pytest.mark.lambda_unit
+class TestAddWesFailureCommentTruncation:
+    """Test that long comments are truncated to 1024 chars."""
+
+    def test_long_error_message_uri_truncated(self, event_builder, lambda_context):
+        """A very long error message URI should result in a truncated comment."""
+        long_uri = "s3://bucket/errors/" + "a" * 2000 + ".log"
+        event = event_builder({
+            "errorType": "TaskFailed",
+            "errorMessageUri": long_uri,
+            "portalRunId": "20250601abcd1234",  # pragma: allowlist secret
+            "executionArn": "arn:aws:states:ap-southeast-2:123456:execution:sfn:exec",
+        })
+
+        handler(event, lambda_context())
+
+        call_kwargs = _mock_workflow.add_comment_to_workflow_run.call_args[1]
+        assert len(call_kwargs["comment"]) <= 1024

--- a/app/lambdas/tests/test_calculate_downsampling_ratios.py
+++ b/app/lambdas/tests/test_calculate_downsampling_ratios.py
@@ -1,0 +1,174 @@
+"""Tests for calculate_downsampling_ratios Lambda function.
+
+This Lambda computes downsampling ratios for tumor/normal pairs based on
+estimated coverage and duplication fractions. It is a pure data transformation
+with no external dependencies.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Path setup for Lambda handler import
+LAMBDA_DIR = Path(__file__).resolve().parents[1] / "calculate_downsampling_ratios_py"
+sys.path.insert(0, str(LAMBDA_DIR))
+
+from calculate_downsampling_ratios import handler  # noqa: E402
+
+
+@pytest.mark.lambda_unit
+class TestNoDownsamplingNeeded:
+    """When the tumor/normal coverage ratio is within [1, 3], no downsampling."""
+
+    def test_ratio_within_bounds(self, event_builder, lambda_context):
+        """Ratio of 2.0 is within bounds — no downsampling needed."""
+        event = event_builder({
+            "normalCoverageEst": 30.0,
+            "tumorCoverageEst": 60.0,
+            "normalDupFracEst": 0.0,
+            "tumorDupFracEst": 0.0,
+        })
+        result = handler(event, lambda_context())
+
+        assert result is None
+
+    def test_ratio_exactly_one(self, event_builder, lambda_context):
+        """Boundary: ratio = 1.0 should not trigger downsampling."""
+        event = event_builder({
+            "normalCoverageEst": 50.0,
+            "tumorCoverageEst": 50.0,
+            "normalDupFracEst": 0.1,
+            "tumorDupFracEst": 0.1,
+        })
+        result = handler(event, lambda_context())
+
+        assert result is None
+
+    def test_ratio_exactly_three(self, event_builder, lambda_context):
+        """Boundary: ratio = 3.0 should not trigger downsampling."""
+        event = event_builder({
+            "normalCoverageEst": 30.0,
+            "tumorCoverageEst": 90.0,
+            "normalDupFracEst": 0.0,
+            "tumorDupFracEst": 0.0,
+        })
+        result = handler(event, lambda_context())
+
+        assert result is None
+
+    def test_with_duplication_adjustments(self, event_builder, lambda_context):
+        """Ratio within bounds after accounting for duplication fractions."""
+        # Effective coverage: normal = 40 * (1 - 0.2) = 32, tumor = 80 * (1 - 0.1) = 72
+        # Ratio = 72 / 32 = 2.25 — within [1, 3]
+        event = event_builder({
+            "normalCoverageEst": 40.0,
+            "tumorCoverageEst": 80.0,
+            "normalDupFracEst": 0.2,
+            "tumorDupFracEst": 0.1,
+        })
+        result = handler(event, lambda_context())
+
+        assert result is None
+
+
+@pytest.mark.lambda_unit
+class TestTumorDownsampling:
+    """When ratio > 3, the tumor should be downsampled."""
+
+    def test_high_ratio_downsamples_tumor(self, event_builder, lambda_context):
+        """Ratio = 6.0 (> MAX_RATIO of 3) should downsample tumor to 0.5."""
+        event = event_builder({
+            "normalCoverageEst": 30.0,
+            "tumorCoverageEst": 180.0,
+            "normalDupFracEst": 0.0,
+            "tumorDupFracEst": 0.0,
+        })
+        result = handler(event, lambda_context())
+
+        assert result is not None
+        assert result["enableFractionalDownSampler"] is True
+        assert "downSamplerTumorSubsample" in result
+        assert result["downSamplerTumorSubsample"] == pytest.approx(0.5)
+
+    def test_moderate_high_ratio(self, event_builder, lambda_context):
+        """Ratio = 4.0 (> 3) should downsample tumor to 0.75."""
+        event = event_builder({
+            "normalCoverageEst": 30.0,
+            "tumorCoverageEst": 120.0,
+            "normalDupFracEst": 0.0,
+            "tumorDupFracEst": 0.0,
+        })
+        result = handler(event, lambda_context())
+
+        assert result is not None
+        assert result["enableFractionalDownSampler"] is True
+        assert result["downSamplerTumorSubsample"] == pytest.approx(0.75)
+
+
+@pytest.mark.lambda_unit
+class TestNormalDownsampling:
+    """When ratio < 1, the normal should be downsampled."""
+
+    def test_low_ratio_downsamples_normal(self, event_builder, lambda_context):
+        """Ratio = 0.5 (< MIN_RATIO of 1) should downsample normal to 0.5."""
+        event = event_builder({
+            "normalCoverageEst": 100.0,
+            "tumorCoverageEst": 50.0,
+            "normalDupFracEst": 0.0,
+            "tumorDupFracEst": 0.0,
+        })
+        result = handler(event, lambda_context())
+
+        assert result is not None
+        assert result["enableFractionalDownSampler"] is True
+        assert "downSamplerNormalSubsample" in result
+        assert result["downSamplerNormalSubsample"] == pytest.approx(0.5)
+
+
+@pytest.mark.lambda_unit
+class TestEdgeCases:
+    """Test error handling for invalid inputs."""
+
+    def test_zero_normal_coverage_raises_error(self, event_builder, lambda_context):
+        """Zero coverage should raise ValueError."""
+        event = event_builder({
+            "normalCoverageEst": 0.0,
+            "tumorCoverageEst": 50.0,
+            "normalDupFracEst": 0.0,
+            "tumorDupFracEst": 0.0,
+        })
+
+        with pytest.raises(ValueError, match="normalCoverageEst must be > 0"):
+            handler(event, lambda_context())
+
+    def test_negative_coverage_raises_error(self, event_builder, lambda_context):
+        """Negative coverage should raise ValueError."""
+        event = event_builder({
+            "normalCoverageEst": -1.0,
+            "tumorCoverageEst": 50.0,
+            "normalDupFracEst": 0.0,
+            "tumorDupFracEst": 0.0,
+        })
+
+        with pytest.raises(ValueError, match="normalCoverageEst must be > 0"):
+            handler(event, lambda_context())
+
+    def test_dup_frac_one_raises_error(self, event_builder, lambda_context):
+        """Duplication fraction of 1.0 would cause division by zero."""
+        event = event_builder({
+            "normalCoverageEst": 50.0,
+            "tumorCoverageEst": 50.0,
+            "normalDupFracEst": 1.0,
+            "tumorDupFracEst": 0.0,
+        })
+
+        with pytest.raises(ValueError, match="normalDupFracEst must be in"):
+            handler(event, lambda_context())
+
+    def test_missing_key_raises_key_error(self, event_builder, lambda_context):
+        """Missing required input field raises KeyError."""
+        event = event_builder({"normalCoverageEst": 50.0})
+
+        with pytest.raises(KeyError):
+            handler(event, lambda_context())

--- a/app/lambdas/tests/test_check_ntsm_external.py
+++ b/app/lambdas/tests/test_check_ntsm_external.py
@@ -1,0 +1,152 @@
+"""Tests for check_ntsm_external Lambda function.
+
+This Lambda validates that tumor and normal FASTQ sets are from related samples
+by running external NTSM (nearest-truth sample matching) checks across all
+cross-products of their FASTQ set IDs.
+"""
+
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup — mock the orcabus_api_tools.fastq layer
+# ---------------------------------------------------------------------------
+LAMBDA_DIR = Path(__file__).resolve().parents[1] / "check_ntsm_external_py"
+
+_mock_api_tools = ModuleType("orcabus_api_tools")
+_mock_fastq = ModuleType("orcabus_api_tools.fastq")
+_mock_fastq.get_fastq_by_rgid = MagicMock()
+_mock_fastq.validate_ntsm_external = MagicMock()
+_mock_api_tools.fastq = _mock_fastq
+
+sys.modules["orcabus_api_tools"] = _mock_api_tools
+sys.modules["orcabus_api_tools.fastq"] = _mock_fastq
+
+sys.path.insert(0, str(LAMBDA_DIR))
+
+from check_ntsm_external import handler  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_mocks():
+    """Reset mocks between tests."""
+    _mock_fastq.get_fastq_by_rgid.reset_mock()
+    _mock_fastq.validate_ntsm_external.reset_mock()
+    yield
+
+
+@pytest.mark.lambda_unit
+class TestCheckNtsmExternalPassing:
+    """Test cases where all cross-product validations pass."""
+
+    def test_single_pair_passing(self, event_builder, lambda_context):
+        """A single normal/tumor pair that passes NTSM returns related=True."""
+        _mock_fastq.get_fastq_by_rgid.side_effect = [
+            {"fastqSetId": "fqs-normal-1"},   # normal rgid
+            {"fastqSetId": "fqs-tumor-1"},    # tumor rgid
+        ]
+        _mock_fastq.validate_ntsm_external.return_value = True
+
+        event = event_builder({
+            "fastqRgidList": ["NORMAL_RGID.1.RUN001"],
+            "tumorFastqRgidList": ["TUMOR_RGID.1.RUN001"],
+        })
+
+        result = handler(event, lambda_context())
+
+        assert result == {"related": True}
+        _mock_fastq.validate_ntsm_external.assert_called_once_with(
+            fastq_set_id="fqs-normal-1",
+            external_fastq_set_id="fqs-tumor-1",
+        )
+
+    def test_multiple_pairs_all_passing(self, event_builder, lambda_context):
+        """Multiple normal and tumor FASTQ sets all passing returns related=True."""
+        _mock_fastq.get_fastq_by_rgid.side_effect = [
+            {"fastqSetId": "fqs-normal-1"},
+            {"fastqSetId": "fqs-normal-2"},
+            {"fastqSetId": "fqs-tumor-1"},
+            {"fastqSetId": "fqs-tumor-2"},
+        ]
+        _mock_fastq.validate_ntsm_external.return_value = True
+
+        event = event_builder({
+            "fastqRgidList": ["N_RGID.1.RUN001", "N_RGID.2.RUN001"],
+            "tumorFastqRgidList": ["T_RGID.1.RUN001", "T_RGID.2.RUN001"],
+        })
+
+        result = handler(event, lambda_context())
+
+        assert result == {"related": True}
+        # Cross product of 2 normal x 2 tumor = 4 calls
+        assert _mock_fastq.validate_ntsm_external.call_count == 4
+
+
+@pytest.mark.lambda_unit
+class TestCheckNtsmExternalFailing:
+    """Test cases where NTSM validation fails."""
+
+    def test_single_pair_failing(self, event_builder, lambda_context):
+        """A single pair that fails NTSM returns related=False."""
+        _mock_fastq.get_fastq_by_rgid.side_effect = [
+            {"fastqSetId": "fqs-normal-1"},
+            {"fastqSetId": "fqs-tumor-1"},
+        ]
+        _mock_fastq.validate_ntsm_external.return_value = False
+
+        event = event_builder({
+            "fastqRgidList": ["NORMAL_RGID.1.RUN001"],
+            "tumorFastqRgidList": ["TUMOR_RGID.1.RUN001"],
+        })
+
+        result = handler(event, lambda_context())
+
+        assert result == {"related": False}
+
+    def test_one_pair_failing_in_cross_product(self, event_builder, lambda_context):
+        """If any pair in the cross-product fails, result is related=False."""
+        _mock_fastq.get_fastq_by_rgid.side_effect = [
+            {"fastqSetId": "fqs-normal-1"},
+            {"fastqSetId": "fqs-tumor-1"},
+            {"fastqSetId": "fqs-tumor-2"},
+        ]
+        # First cross-product passes, second fails
+        _mock_fastq.validate_ntsm_external.side_effect = [True, False]
+
+        event = event_builder({
+            "fastqRgidList": ["N_RGID.1.RUN001"],
+            "tumorFastqRgidList": ["T_RGID.1.RUN001", "T_RGID.2.RUN001"],
+        })
+
+        result = handler(event, lambda_context())
+
+        assert result == {"related": False}
+
+
+@pytest.mark.lambda_unit
+class TestCheckNtsmExternalDeduplication:
+    """Test that duplicate FASTQ set IDs are deduplicated."""
+
+    def test_duplicate_rgids_same_fastq_set(self, event_builder, lambda_context):
+        """Multiple RGIDs mapping to the same FASTQ set should be deduplicated."""
+        _mock_fastq.get_fastq_by_rgid.side_effect = [
+            {"fastqSetId": "fqs-normal-1"},   # Both normal RGIDs map to same set
+            {"fastqSetId": "fqs-normal-1"},
+            {"fastqSetId": "fqs-tumor-1"},
+        ]
+        _mock_fastq.validate_ntsm_external.return_value = True
+
+        event = event_builder({
+            "fastqRgidList": ["N_RGID.1.RUN001", "N_RGID.2.RUN001"],
+            "tumorFastqRgidList": ["T_RGID.1.RUN001"],
+        })
+
+        result = handler(event, lambda_context())
+
+        assert result == {"related": True}
+        # Only 1 unique normal set x 1 tumor set = 1 call
+        _mock_fastq.validate_ntsm_external.assert_called_once()

--- a/app/lambdas/tests/test_check_ntsm_internal.py
+++ b/app/lambdas/tests/test_check_ntsm_internal.py
@@ -1,0 +1,161 @@
+"""Tests for check_ntsm_internal Lambda function.
+
+This Lambda validates that all FASTQ sets within a list of RGIDs are from the
+same sample, using internal and cross-set NTSM validation.
+"""
+
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup — mock the orcabus_api_tools.fastq layer
+# ---------------------------------------------------------------------------
+LAMBDA_DIR = Path(__file__).resolve().parents[1] / "check_ntsm_internal_py"
+
+_mock_api_tools = ModuleType("orcabus_api_tools")
+_mock_fastq = ModuleType("orcabus_api_tools.fastq")
+_mock_fastq.get_fastq_by_rgid = MagicMock()
+_mock_fastq.validate_ntsm_internal = MagicMock()
+_mock_fastq.validate_ntsm_external = MagicMock()
+_mock_api_tools.fastq = _mock_fastq
+
+sys.modules["orcabus_api_tools"] = _mock_api_tools
+sys.modules["orcabus_api_tools.fastq"] = _mock_fastq
+
+sys.path.insert(0, str(LAMBDA_DIR))
+
+from check_ntsm_internal import handler, non_duplicate_cross_product  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_mocks():
+    """Reset mocks between tests."""
+    _mock_fastq.get_fastq_by_rgid.reset_mock()
+    _mock_fastq.validate_ntsm_internal.reset_mock()
+    _mock_fastq.validate_ntsm_external.reset_mock()
+    yield
+
+
+@pytest.mark.lambda_unit
+class TestCheckNtsmInternalEmptyInput:
+    """Test behaviour with empty RGID list."""
+
+    def test_empty_list_returns_none(self, event_builder, lambda_context):
+        """An empty RGID list should return related=None."""
+        event = event_builder({"fastqRgidList": []})
+
+        result = handler(event, lambda_context())
+
+        assert result == {"related": None}
+
+
+@pytest.mark.lambda_unit
+class TestCheckNtsmInternalSingleSet:
+    """Test behaviour with a single FASTQ set (internal validation only)."""
+
+    def test_single_rgid_passing(self, event_builder, lambda_context):
+        """A single RGID that passes internal NTSM returns related=True."""
+        _mock_fastq.get_fastq_by_rgid.return_value = {"fastqSetId": "fqs-001"}
+        _mock_fastq.validate_ntsm_internal.return_value = True
+
+        event = event_builder({"fastqRgidList": ["RGID.1.RUN001"]})
+
+        result = handler(event, lambda_context())
+
+        assert result == {"related": True}
+        _mock_fastq.validate_ntsm_internal.assert_called_once_with("fqs-001")
+
+    def test_single_rgid_failing(self, event_builder, lambda_context):
+        """A single RGID that fails internal NTSM returns related=False."""
+        _mock_fastq.get_fastq_by_rgid.return_value = {"fastqSetId": "fqs-001"}
+        _mock_fastq.validate_ntsm_internal.return_value = False
+
+        event = event_builder({"fastqRgidList": ["RGID.1.RUN001"]})
+
+        result = handler(event, lambda_context())
+
+        assert result == {"related": False}
+
+
+@pytest.mark.lambda_unit
+class TestCheckNtsmInternalMultipleSets:
+    """Test behaviour with multiple FASTQ sets (external cross-validation)."""
+
+    def test_two_sets_both_passing(self, event_builder, lambda_context):
+        """Two distinct FASTQ sets that pass external NTSM return related=True."""
+        _mock_fastq.get_fastq_by_rgid.side_effect = [
+            {"fastqSetId": "fqs-001"},
+            {"fastqSetId": "fqs-002"},
+        ]
+        _mock_fastq.validate_ntsm_external.return_value = True
+
+        event = event_builder({"fastqRgidList": ["RGID.1.RUN001", "RGID.2.RUN001"]})
+
+        result = handler(event, lambda_context())
+
+        assert result == {"related": True}
+        # Non-duplicate cross product of 2 items = 1 pair
+        _mock_fastq.validate_ntsm_external.assert_called_once_with("fqs-001", "fqs-002")
+
+    def test_two_sets_one_failing(self, event_builder, lambda_context):
+        """If external NTSM fails between any pair, result is related=False."""
+        _mock_fastq.get_fastq_by_rgid.side_effect = [
+            {"fastqSetId": "fqs-001"},
+            {"fastqSetId": "fqs-002"},
+        ]
+        _mock_fastq.validate_ntsm_external.return_value = False
+
+        event = event_builder({"fastqRgidList": ["RGID.1.RUN001", "RGID.2.RUN001"]})
+
+        result = handler(event, lambda_context())
+
+        assert result == {"related": False}
+
+    def test_three_sets_all_passing(self, event_builder, lambda_context):
+        """Three distinct FASTQ sets with all cross pairs passing return related=True."""
+        _mock_fastq.get_fastq_by_rgid.side_effect = [
+            {"fastqSetId": "fqs-001"},
+            {"fastqSetId": "fqs-002"},
+            {"fastqSetId": "fqs-003"},
+        ]
+        _mock_fastq.validate_ntsm_external.return_value = True
+
+        event = event_builder({"fastqRgidList": ["RGID.1.R", "RGID.2.R", "RGID.3.R"]})
+
+        result = handler(event, lambda_context())
+
+        assert result == {"related": True}
+        # Non-duplicate cross product of 3 = 3 pairs
+        assert _mock_fastq.validate_ntsm_external.call_count == 3
+
+
+@pytest.mark.lambda_unit
+class TestNonDuplicateCrossProduct:
+    """Test the non_duplicate_cross_product utility function."""
+
+    def test_two_items(self):
+        """Two items should produce one pair."""
+        result = non_duplicate_cross_product(["a", "b"])
+        assert result == [("a", "b")]
+
+    def test_three_items(self):
+        """Three items should produce three pairs (no duplicates or reverses)."""
+        result = non_duplicate_cross_product(["a", "b", "c"])
+        assert len(result) == 3
+        assert ("a", "b") in result
+        assert ("a", "c") in result
+        assert ("b", "c") in result
+
+    def test_single_item(self):
+        """A single item should produce no pairs."""
+        result = non_duplicate_cross_product(["a"])
+        assert result == []
+
+    def test_empty_list(self):
+        """An empty list should produce no pairs."""
+        result = non_duplicate_cross_product([])
+        assert result == []

--- a/app/lambdas/tests/test_compare_payload.py
+++ b/app/lambdas/tests/test_compare_payload.py
@@ -1,0 +1,135 @@
+"""Tests for compare_payload Lambda function."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Path setup for Lambda handler import
+LAMBDA_DIR = Path(__file__).resolve().parents[1] / "compare_payload_py"
+sys.path.insert(0, str(LAMBDA_DIR))
+
+from compare_payload import handler  # noqa: E402
+
+
+@pytest.mark.lambda_unit
+class TestComparePayloadIdentical:
+    """Test cases where payloads are identical (hasChanged=False)."""
+
+    def test_identical_simple_payloads(self, event_builder, lambda_context):
+        """Two identical flat payloads should return hasChanged=False."""
+        payload = {"key": "value", "number": 42}
+        event = event_builder({"oldPayload": payload, "newPayload": payload})
+        ctx = lambda_context(function_name="compare-payload")
+
+        result = handler(event, ctx)
+
+        assert result == {"hasChanged": False}
+
+    def test_identical_nested_payloads(self, event_builder, lambda_context):
+        """Two identical nested payloads should return hasChanged=False."""
+        payload = {
+            "inputs": {
+                "sampleName": "SMP001",
+                "sequenceData": {
+                    "fastqListRows": [
+                        {"rgid": "RG001", "lane": 1, "read1FileUri": "s3://bucket/r1.fq.gz"}
+                    ]
+                },
+            },
+            "engineParameters": {"pipelineId": "pipeline-123", "projectId": "proj-456"},
+        }
+        event = event_builder({"oldPayload": payload, "newPayload": payload})
+        ctx = lambda_context()
+
+        result = handler(event, ctx)
+
+        assert result == {"hasChanged": False}
+
+    def test_identical_empty_payloads(self, event_builder, lambda_context):
+        """Two empty payloads should return hasChanged=False."""
+        event = event_builder({"oldPayload": {}, "newPayload": {}})
+        ctx = lambda_context()
+
+        result = handler(event, ctx)
+
+        assert result == {"hasChanged": False}
+
+
+@pytest.mark.lambda_unit
+class TestComparePayloadChanged:
+    """Test cases where payloads differ (hasChanged=True)."""
+
+    def test_added_key(self, event_builder, lambda_context):
+        """New payload with an additional key should return hasChanged=True."""
+        old = {"key": "value"}
+        new = {"key": "value", "extra": "data"}
+        event = event_builder({"oldPayload": old, "newPayload": new})
+        ctx = lambda_context()
+
+        result = handler(event, ctx)
+
+        assert result == {"hasChanged": True}
+
+    def test_removed_key(self, event_builder, lambda_context):
+        """New payload with a removed key should return hasChanged=True."""
+        old = {"key": "value", "extra": "data"}
+        new = {"key": "value"}
+        event = event_builder({"oldPayload": old, "newPayload": new})
+        ctx = lambda_context()
+
+        result = handler(event, ctx)
+
+        assert result == {"hasChanged": True}
+
+    def test_changed_value(self, event_builder, lambda_context):
+        """New payload with a changed value should return hasChanged=True."""
+        old = {"pipelineId": "pipeline-old"}
+        new = {"pipelineId": "pipeline-new"}
+        event = event_builder({"oldPayload": old, "newPayload": new})
+        ctx = lambda_context()
+
+        result = handler(event, ctx)
+
+        assert result == {"hasChanged": True}
+
+    def test_changed_nested_value(self, event_builder, lambda_context):
+        """A change deep in a nested structure should be detected."""
+        old = {
+            "inputs": {
+                "sequenceData": {"fastqListRows": [{"rgid": "RG001", "lane": 1}]}
+            }
+        }
+        new = {
+            "inputs": {
+                "sequenceData": {"fastqListRows": [{"rgid": "RG001", "lane": 2}]}
+            }
+        }
+        event = event_builder({"oldPayload": old, "newPayload": new})
+        ctx = lambda_context()
+
+        result = handler(event, ctx)
+
+        assert result == {"hasChanged": True}
+
+    def test_changed_list_order(self, event_builder, lambda_context):
+        """A reordered list should be detected as a change (order-sensitive)."""
+        old = {"items": [1, 2, 3]}
+        new = {"items": [3, 2, 1]}
+        event = event_builder({"oldPayload": old, "newPayload": new})
+        ctx = lambda_context()
+
+        result = handler(event, ctx)
+
+        assert result == {"hasChanged": True}
+
+    def test_type_change(self, event_builder, lambda_context):
+        """Changing a value type (string to int) should be detected."""
+        old = {"count": "42"}
+        new = {"count": 42}
+        event = event_builder({"oldPayload": old, "newPayload": new})
+        ctx = lambda_context()
+
+        result = handler(event, ctx)
+
+        assert result == {"hasChanged": True}

--- a/app/lambdas/tests/test_convert_icav2_wes_state_change_event_to_wrsc_event.py
+++ b/app/lambdas/tests/test_convert_icav2_wes_state_change_event_to_wrsc_event.py
@@ -1,0 +1,250 @@
+"""Tests for convert_icav2_wes_state_change_event_to_wrsc_event Lambda function.
+
+This Lambda converts an ICAv2 WES state change event into a WorkflowRunStateChange
+event. It looks up the workflow run by portal run ID and constructs the WRSC payload.
+"""
+
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup — mock the orcabus_api_tools.workflow layer
+# ---------------------------------------------------------------------------
+LAMBDA_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "convert_icav2_wes_state_change_event_to_wrsc_event_py"
+)
+
+_mock_api_tools = ModuleType("orcabus_api_tools")
+_mock_workflow = ModuleType("orcabus_api_tools.workflow")
+_mock_workflow.get_workflow_run_from_portal_run_id = MagicMock()
+_mock_workflow.get_latest_payload_from_workflow_run = MagicMock()
+_mock_api_tools.workflow = _mock_workflow
+
+sys.modules["orcabus_api_tools"] = _mock_api_tools
+sys.modules["orcabus_api_tools.workflow"] = _mock_workflow
+
+sys.path.insert(0, str(LAMBDA_DIR))
+
+from convert_icav2_wes_state_change_event_to_wrsc_event import handler  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Test data factories
+# ---------------------------------------------------------------------------
+
+
+def _make_workflow_run(portal_run_id="20250606efgh1234"):
+    """Build a minimal workflow run object as returned by the API."""
+    return {
+        "orcabusId": "wfr.abc123",
+        "portalRunId": portal_run_id,
+        "workflowRunName": "umccr--automated--dragen-wgts-dna--4-4-4--" + portal_run_id,
+        "workflow": {
+            "workflowName": "dragen-wgts-dna",
+            "workflowVersion": "4.4.4",
+        },
+        "libraries": [
+            {"libraryId": "L2301197", "orcabusId": "lib.ABC123"}
+        ],
+        "linkedLibraries": [
+            {"libraryId": "L2301197", "orcabusId": "lib.ABC123"}
+        ],
+    }
+
+
+def _make_payload():
+    """Build a minimal latest payload object."""
+    return {
+        "version": "2025.06.04",
+        "data": {
+            "inputs": {
+                "sampleName": "L2301197",
+                "reference": {"name": "hg38", "structure": "linear"},
+            },
+            "engineParameters": {
+                "pipelineId": "pipe-123",
+                "projectId": "proj-456",
+                "outputUri": "s3://bucket/output/",
+                "logsUri": "s3://bucket/logs/",
+            },
+            "tags": {"libraryId": "L2301197"},
+        },
+    }
+
+
+def _make_icav2_wes_event(status="RUNNING", portal_run_id="20250606efgh1234"):
+    """Build a minimal ICAv2 WES state change event."""
+    return {
+        "icav2WesStateChangeEvent": {
+            "id": "iwa.01JWAGE5PWS5JN48VWNPYSTJRN",
+            "name": f"umccr--automated--dragen-wgts-dna--4-4-4--{portal_run_id}",
+            "status": status,
+            "tags": {"portalRunId": portal_run_id, "libraryId": "L2301197"},
+            "icav2AnalysisId": "analysis-789",
+            "inputs": {},
+            "engineParameters": {},
+        }
+    }
+
+
+@pytest.fixture(autouse=True)
+def _reset_mocks():
+    """Reset mocks and provide default return values."""
+    _mock_workflow.get_workflow_run_from_portal_run_id.reset_mock()
+    _mock_workflow.get_latest_payload_from_workflow_run.reset_mock()
+    _mock_workflow.get_workflow_run_from_portal_run_id.return_value = _make_workflow_run()
+    _mock_workflow.get_latest_payload_from_workflow_run.return_value = _make_payload()
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Tests: RUNNING status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.lambda_unit
+class TestConvertRunningEvent:
+    """Test conversion of a RUNNING status event."""
+
+    def test_output_contains_wrsc_event(self, event_builder, lambda_context):
+        """Output should contain workflowRunStateChangeEvent key."""
+        event = _make_icav2_wes_event(status="RUNNING")
+
+        result = handler(event, lambda_context())
+
+        assert "workflowRunStateChangeEvent" in result
+
+    def test_status_is_running(self, event_builder, lambda_context):
+        """Status should be RUNNING."""
+        event = _make_icav2_wes_event(status="RUNNING")
+
+        result = handler(event, lambda_context())
+
+        assert result["workflowRunStateChangeEvent"]["status"] == "RUNNING"
+
+    def test_portal_run_id_preserved(self, event_builder, lambda_context):
+        """Portal run ID should be preserved from the event tags."""
+        event = _make_icav2_wes_event(status="RUNNING", portal_run_id="20250601test1234")
+        _mock_workflow.get_workflow_run_from_portal_run_id.return_value = _make_workflow_run("20250601test1234")
+
+        result = handler(event, lambda_context())
+
+        assert result["workflowRunStateChangeEvent"]["portalRunId"] == "20250601test1234"
+
+    def test_workflow_details_present(self, event_builder, lambda_context):
+        """Workflow name and version should be in the output."""
+        event = _make_icav2_wes_event(status="RUNNING")
+
+        result = handler(event, lambda_context())
+
+        wrsc = result["workflowRunStateChangeEvent"]
+        assert wrsc["workflow"]["name"] == "dragen-wgts-dna"
+        assert wrsc["workflow"]["version"] == "4.4.4"
+
+    def test_libraries_preserved(self, event_builder, lambda_context):
+        """Libraries from the workflow run should be preserved."""
+        event = _make_icav2_wes_event(status="RUNNING")
+
+        result = handler(event, lambda_context())
+
+        assert result["workflowRunStateChangeEvent"]["libraries"] == [
+            {"libraryId": "L2301197", "orcabusId": "lib.ABC123"}
+        ]
+
+    def test_no_error_fields_for_running(self, event_builder, lambda_context):
+        """RUNNING events should have null error fields."""
+        event = _make_icav2_wes_event(status="RUNNING")
+
+        result = handler(event, lambda_context())
+
+        assert result["errorMessageUri"] is None
+        assert result["errorType"] is None
+
+    def test_execution_id_set(self, event_builder, lambda_context):
+        """executionId should be set from icav2AnalysisId."""
+        event = _make_icav2_wes_event(status="RUNNING")
+
+        result = handler(event, lambda_context())
+
+        assert result["workflowRunStateChangeEvent"]["executionId"] == "analysis-789"
+
+
+# ---------------------------------------------------------------------------
+# Tests: SUCCEEDED status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.lambda_unit
+class TestConvertSucceededEvent:
+    """Test conversion of a SUCCEEDED status event."""
+
+    def test_outputs_generated_for_germline(self, event_builder, lambda_context):
+        """SUCCEEDED should generate output paths for germline variant calling."""
+        event = _make_icav2_wes_event(status="SUCCEEDED")
+
+        result = handler(event, lambda_context())
+
+        payload_data = result["workflowRunStateChangeEvent"]["payload"]["data"]
+        assert "outputs" in payload_data
+        assert "dragenGermlineVariantCallingOutputRelPath" in payload_data["outputs"]
+        assert payload_data["outputs"]["dragenGermlineVariantCallingOutputRelPath"] == (
+            "L2301197__hg38__linear__dragen_wgts_dna_germline_variant_calling/"
+        )
+
+    def test_somatic_output_for_tumor_normal(self, event_builder, lambda_context):
+        """SUCCEEDED with tumor sample should generate somatic output paths."""
+        payload = _make_payload()
+        payload["data"]["inputs"]["tumorSampleName"] = "T2301198"
+        _mock_workflow.get_latest_payload_from_workflow_run.return_value = payload
+
+        event = _make_icav2_wes_event(status="SUCCEEDED")
+
+        result = handler(event, lambda_context())
+
+        payload_data = result["workflowRunStateChangeEvent"]["payload"]["data"]
+        assert "dragenSomaticVariantCallingOutputRelPath" in payload_data["outputs"]
+        assert "T2301198" in payload_data["outputs"]["dragenSomaticVariantCallingOutputRelPath"]
+
+    def test_multiqc_output_for_germline(self, event_builder, lambda_context):
+        """SUCCEEDED germline should generate multiQc output path."""
+        event = _make_icav2_wes_event(status="SUCCEEDED")
+
+        result = handler(event, lambda_context())
+
+        payload_data = result["workflowRunStateChangeEvent"]["payload"]["data"]
+        assert payload_data["outputs"]["multiQcOutputRelPath"] == "L2301197_multiqc/"
+
+
+# ---------------------------------------------------------------------------
+# Tests: FAILED status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.lambda_unit
+class TestConvertFailedEvent:
+    """Test conversion of a FAILED status event."""
+
+    def test_error_fields_populated(self, event_builder, lambda_context):
+        """FAILED events should have errorType and errorMessageUri populated."""
+        event = _make_icav2_wes_event(status="FAILED")
+        event["icav2WesStateChangeEvent"]["errorType"] = "TaskFailed"
+        event["icav2WesStateChangeEvent"]["errorMessageUri"] = "s3://bucket/error.log"
+
+        result = handler(event, lambda_context())
+
+        assert result["errorType"] == "TaskFailed"
+        assert result["errorMessageUri"] == "s3://bucket/error.log"
+
+    def test_status_is_failed(self, event_builder, lambda_context):
+        """Status should be FAILED."""
+        event = _make_icav2_wes_event(status="FAILED")
+        event["icav2WesStateChangeEvent"]["errorType"] = "TaskFailed"
+
+        result = handler(event, lambda_context())
+
+        assert result["workflowRunStateChangeEvent"]["status"] == "FAILED"

--- a/app/lambdas/tests/test_dragen_wgts_dna_ready_to_icav2_wes_request.py
+++ b/app/lambdas/tests/test_dragen_wgts_dna_ready_to_icav2_wes_request.py
@@ -1,0 +1,269 @@
+"""Tests for dragen_wgts_dna_ready_to_icav2_wes_request Lambda function.
+
+This Lambda converts a DRAGEN WGTS DNA READY event detail into an ICAv2 WES
+request event. It performs pure data transformations:
+- Converts camelCase input keys to snake_case
+- Converts file URIs to CWL File/Directory objects
+- Restructures the event into ICAv2 WES request format
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Path setup for Lambda handler import
+LAMBDA_DIR = Path(__file__).resolve().parents[1] / "dragen_wgts_dna_ready_to_icav2_wes_request_py"
+sys.path.insert(0, str(LAMBDA_DIR))
+
+from dragen_wgts_dna_ready_to_icav2_wes_request import handler  # noqa: E402
+
+
+def _make_ready_event(
+    *,
+    portal_run_id="20250606efgh1234",
+    workflow_run_name="umccr--automated--dragen-wgts-dna--4-4-4--20250606efgh1234",
+    inputs=None,
+    engine_parameters=None,
+    tags=None,
+):
+    """Helper to build a minimal READY event detail."""
+    if inputs is None:
+        inputs = {
+            "sampleName": "L2301197",
+            "reference": {
+                "name": "hg38",
+                "structure": "graph",
+                "tarball": "s3://bucket/reference.tar.gz",
+            },
+            "sequenceData": {
+                "fastqListRows": [
+                    {
+                        "rgid": "RG001",
+                        "rglb": "L2301197",
+                        "rgsm": "L2301197",
+                        "lane": 1,
+                        "read1FileUri": "s3://bucket/R1.fastq.ora",
+                        "read2FileUri": "s3://bucket/R2.fastq.ora",
+                    }
+                ]
+            },
+        }
+    if engine_parameters is None:
+        engine_parameters = {
+            "pipelineId": "pipeline-123",
+            "projectId": "proj-456",
+            "outputUri": "s3://bucket/output/",
+            "logsUri": "s3://bucket/logs/",
+        }
+    if tags is None:
+        tags = {"libraryId": "L2301197"}
+
+    return {
+        "dragenWgtsDnaReadyEventDetail": {
+            "portalRunId": portal_run_id,
+            "timestamp": "2025-06-06T04:39:31+00:00",
+            "status": "READY",
+            "workflowName": "dragen-wgts-dna",
+            "workflowVersion": "4.4.4",
+            "workflowRunName": workflow_run_name,
+            "linkedLibraries": [{"libraryId": "L2301197", "orcabusId": "lib.ABC123"}],
+            "payload": {
+                "refId": "ref-uuid",
+                "version": "2025.06.06",
+                "data": {
+                    "inputs": inputs,
+                    "engineParameters": engine_parameters,
+                    "tags": tags,
+                },
+            },
+        }
+    }
+
+
+@pytest.mark.lambda_unit
+class TestReadyToWesRequestHappyPath:
+    """Test the happy-path conversion from READY event to ICAv2 WES request."""
+
+    def test_output_structure(self, lambda_context):
+        """Output should contain icav2WesRequestEventDetail with name, inputs, engineParameters, tags."""
+        event = _make_ready_event()
+        result = handler(event, lambda_context())
+
+        assert "icav2WesRequestEventDetail" in result
+        detail = result["icav2WesRequestEventDetail"]
+        assert "name" in detail
+        assert "inputs" in detail
+        assert "engineParameters" in detail
+        assert "tags" in detail
+
+    def test_workflow_run_name_preserved(self, lambda_context):
+        """The workflow run name should be passed through as 'name'."""
+        event = _make_ready_event(
+            workflow_run_name="umccr--automated--dragen-wgts-dna--4-4-4--20250606test1234"
+        )
+        result = handler(event, lambda_context())
+
+        assert result["icav2WesRequestEventDetail"]["name"] == (
+            "umccr--automated--dragen-wgts-dna--4-4-4--20250606test1234"
+        )
+
+    def test_portal_run_id_added_to_tags(self, lambda_context):
+        """The portalRunId should be added to the tags."""
+        event = _make_ready_event(portal_run_id="20250101abcd5678")
+        result = handler(event, lambda_context())
+
+        tags = result["icav2WesRequestEventDetail"]["tags"]
+        assert tags["portalRunId"] == "20250101abcd5678"  # pragma: allowlist secret
+
+    def test_original_tags_preserved(self, lambda_context):
+        """Original tags from the READY event should be preserved."""
+        event = _make_ready_event(tags={"libraryId": "L999", "subjectId": "SBJ001"})
+        result = handler(event, lambda_context())
+
+        tags = result["icav2WesRequestEventDetail"]["tags"]
+        assert tags["libraryId"] == "L999"
+        assert tags["subjectId"] == "SBJ001"
+
+    def test_engine_parameters_passed_through(self, lambda_context):
+        """Engine parameters should be passed through unchanged."""
+        engine_params = {
+            "pipelineId": "pipe-abc",
+            "projectId": "proj-xyz",
+            "outputUri": "s3://out/",
+            "logsUri": "s3://logs/",
+        }
+        event = _make_ready_event(engine_parameters=engine_params)
+        result = handler(event, lambda_context())
+
+        assert result["icav2WesRequestEventDetail"]["engineParameters"] == engine_params
+
+
+@pytest.mark.lambda_unit
+class TestCamelToSnakeCaseConversion:
+    """Test that input keys are converted from camelCase to snake_case."""
+
+    def test_top_level_keys_converted(self, lambda_context):
+        """Top-level input keys should be snake_case."""
+        event = _make_ready_event()
+        result = handler(event, lambda_context())
+
+        inputs = result["icav2WesRequestEventDetail"]["inputs"]
+        assert "sample_name" in inputs
+        assert "sampleName" not in inputs
+
+    def test_nested_keys_converted(self, lambda_context):
+        """Nested keys should also be snake_case."""
+        inputs = {
+            "sampleName": "SMP001",
+            "reference": {"name": "hg38", "structure": "graph", "tarball": "s3://ref.tar.gz"},
+            "alignmentOptions": {"enableDuplicateMarking": True},
+            "sequenceData": {
+                "fastqListRows": [
+                    {"rgid": "RG1", "rglb": "L1", "rgsm": "S1", "lane": 1,
+                     "read1FileUri": "s3://r1.fq", "read2FileUri": "s3://r2.fq"}
+                ]
+            },
+        }
+        event = _make_ready_event(inputs=inputs)
+        result = handler(event, lambda_context())
+
+        converted = result["icav2WesRequestEventDetail"]["inputs"]
+        assert "alignment_options" in converted
+        assert "enable_duplicate_marking" in converted["alignment_options"]
+
+
+@pytest.mark.lambda_unit
+class TestCwlFileConversion:
+    """Test that file URIs are converted to CWL File objects."""
+
+    def test_reference_tarball_converted(self, lambda_context):
+        """Reference tarball URI should become a CWL File object."""
+        event = _make_ready_event()
+        result = handler(event, lambda_context())
+
+        ref = result["icav2WesRequestEventDetail"]["inputs"]["reference"]
+        assert ref["tarball"] == {"class": "File", "location": "s3://bucket/reference.tar.gz"}
+
+    def test_fastq_read_uris_converted(self, lambda_context):
+        """read1FileUri and read2FileUri should become read_1/read_2 CWL File objects."""
+        event = _make_ready_event()
+        result = handler(event, lambda_context())
+
+        rows = result["icav2WesRequestEventDetail"]["inputs"]["sequence_data"]["fastq_list_rows"]
+        assert len(rows) == 1
+        assert rows[0]["read_1"] == {"class": "File", "location": "s3://bucket/R1.fastq.ora"}
+        assert rows[0]["read_2"] == {"class": "File", "location": "s3://bucket/R2.fastq.ora"}
+
+    def test_ora_reference_converted(self, lambda_context):
+        """oraReference URI should become a CWL File object."""
+        inputs = {
+            "sampleName": "SMP001",
+            "reference": {"name": "hg38", "structure": "graph", "tarball": "s3://ref.tar.gz"},
+            "oraReference": "s3://bucket/ora_ref.tar.gz",
+            "sequenceData": {
+                "fastqListRows": [
+                    {"rgid": "RG1", "rglb": "L1", "rgsm": "S1", "lane": 1,
+                     "read1FileUri": "s3://r1.fq", "read2FileUri": "s3://r2.fq"}
+                ]
+            },
+        }
+        event = _make_ready_event(inputs=inputs)
+        result = handler(event, lambda_context())
+
+        converted = result["icav2WesRequestEventDetail"]["inputs"]
+        assert converted["ora_reference"] == {"class": "File", "location": "s3://bucket/ora_ref.tar.gz"}
+
+    def test_somatic_reference_tarball_converted(self, lambda_context):
+        """somaticReference.tarball should become a CWL File object."""
+        inputs = {
+            "sampleName": "SMP001",
+            "reference": {"name": "hg38", "structure": "graph", "tarball": "s3://ref.tar.gz"},
+            "somaticReference": {"name": "hg38", "structure": "graph", "tarball": "s3://somatic_ref.tar.gz"},
+            "sequenceData": {
+                "fastqListRows": [
+                    {"rgid": "RG1", "rglb": "L1", "rgsm": "S1", "lane": 1,
+                     "read1FileUri": "s3://r1.fq", "read2FileUri": "s3://r2.fq"}
+                ]
+            },
+        }
+        event = _make_ready_event(inputs=inputs)
+        result = handler(event, lambda_context())
+
+        converted = result["icav2WesRequestEventDetail"]["inputs"]
+        assert converted["somatic_reference"]["tarball"] == {
+            "class": "File",
+            "location": "s3://somatic_ref.tar.gz",
+        }
+
+
+@pytest.mark.lambda_unit
+class TestTumorNormalInputs:
+    """Test tumor/normal paired inputs."""
+
+    def test_tumor_fastq_list_rows_converted(self, lambda_context):
+        """tumorSequenceData.fastqListRows should also get CWL File conversion."""
+        inputs = {
+            "sampleName": "NORMAL001",
+            "tumorSampleName": "TUMOR001",
+            "reference": {"name": "hg38", "structure": "graph", "tarball": "s3://ref.tar.gz"},
+            "sequenceData": {
+                "fastqListRows": [
+                    {"rgid": "RG_N", "rglb": "LN", "rgsm": "SN", "lane": 1,
+                     "read1FileUri": "s3://normal_r1.fq", "read2FileUri": "s3://normal_r2.fq"}
+                ]
+            },
+            "tumorSequenceData": {
+                "fastqListRows": [
+                    {"rgid": "RG_T", "rglb": "LT", "rgsm": "ST", "lane": 1,
+                     "read1FileUri": "s3://tumor_r1.fq", "read2FileUri": "s3://tumor_r2.fq"}
+                ]
+            },
+        }
+        event = _make_ready_event(inputs=inputs)
+        result = handler(event, lambda_context())
+
+        converted = result["icav2WesRequestEventDetail"]["inputs"]
+        tumor_rows = converted["tumor_sequence_data"]["fastq_list_rows"]
+        assert tumor_rows[0]["read_1"] == {"class": "File", "location": "s3://tumor_r1.fq"}
+        assert tumor_rows[0]["read_2"] == {"class": "File", "location": "s3://tumor_r2.fq"}

--- a/app/lambdas/tests/test_generate_workflow_run_name_and_portal_run_id.py
+++ b/app/lambdas/tests/test_generate_workflow_run_name_and_portal_run_id.py
@@ -1,0 +1,114 @@
+"""Tests for generate_workflow_run_name_and_portal_run_id Lambda function.
+
+This Lambda generates a portal run ID and workflow run name by calling
+orcabus_api_tools.workflow utilities. The generated names follow a
+deterministic format based on workflow name, version, and portal run ID.
+"""
+
+import os
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup — mock the orcabus_api_tools.workflow layer
+# ---------------------------------------------------------------------------
+LAMBDA_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "generate_workflow_run_name_and_portal_run_id_py"
+)
+
+_mock_api_tools = ModuleType("orcabus_api_tools")
+_mock_workflow = ModuleType("orcabus_api_tools.workflow")
+_mock_workflow.create_portal_run_id = MagicMock()
+_mock_workflow.create_workflow_run_name_from_workflow_name_workflow_version_and_portal_run_id = MagicMock()
+_mock_api_tools.workflow = _mock_workflow
+
+sys.modules["orcabus_api_tools"] = _mock_api_tools
+sys.modules["orcabus_api_tools.workflow"] = _mock_workflow
+
+sys.path.insert(0, str(LAMBDA_DIR))
+
+from generate_workflow_run_name_and_portal_run_id import handler  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _set_env_vars():
+    """Set required environment variables for the Lambda."""
+    env_vars = {
+        "WORKFLOW_NAME": "dragen-wgts-dna",
+        "WORKFLOW_VERSION": "4.4.4",
+    }
+    with patch.dict(os.environ, env_vars):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _reset_mocks():
+    """Reset mocks between tests."""
+    _mock_workflow.create_portal_run_id.reset_mock()
+    _mock_workflow.create_workflow_run_name_from_workflow_name_workflow_version_and_portal_run_id.reset_mock()
+    # Set default return values
+    _mock_workflow.create_portal_run_id.return_value = "20250606abcd1234"
+    _mock_workflow.create_workflow_run_name_from_workflow_name_workflow_version_and_portal_run_id.return_value = (
+        "umccr--automated--dragen-wgts-dna--4-4-4--20250606abcd1234"
+    )
+    yield
+
+
+@pytest.mark.lambda_unit
+class TestGenerateWorkflowRunNameAndPortalRunId:
+    """Test the workflow run name and portal run ID generation."""
+
+    def test_returns_portal_run_id(self, event_builder, lambda_context):
+        """Handler should return the generated portalRunId."""
+        event = event_builder({})
+
+        result = handler(event, lambda_context())
+
+        assert result["portalRunId"] == "20250606abcd1234"  # pragma: allowlist secret
+
+    def test_returns_workflow_run_name(self, event_builder, lambda_context):
+        """Handler should return the generated workflowRunName."""
+        event = event_builder({})
+
+        result = handler(event, lambda_context())
+
+        assert result["workflowRunName"] == (
+            "umccr--automated--dragen-wgts-dna--4-4-4--20250606abcd1234"
+        )
+
+    def test_calls_create_portal_run_id(self, event_builder, lambda_context):
+        """Handler should call create_portal_run_id."""
+        event = event_builder({})
+
+        handler(event, lambda_context())
+
+        _mock_workflow.create_portal_run_id.assert_called_once()
+
+    def test_calls_create_workflow_run_name_with_correct_args(self, event_builder, lambda_context):
+        """Handler should call create_workflow_run_name with env var values."""
+        event = event_builder({})
+
+        handler(event, lambda_context())
+
+        _mock_workflow.create_workflow_run_name_from_workflow_name_workflow_version_and_portal_run_id.assert_called_once_with(
+            workflow_name="dragen-wgts-dna",
+            workflow_version="4.4.4",
+            portal_run_id="20250606abcd1234",
+        )
+
+    def test_different_workflow_version(self, event_builder, lambda_context):
+        """Handler should use the WORKFLOW_VERSION env var."""
+        _mock_workflow.create_workflow_run_name_from_workflow_name_workflow_version_and_portal_run_id.return_value = (
+            "umccr--automated--dragen-wgts-dna--5-0-0--20250606abcd1234"
+        )
+
+        with patch.dict(os.environ, {"WORKFLOW_VERSION": "5.0.0"}):
+            event = event_builder({})
+            result = handler(event, lambda_context())
+
+        assert "5-0-0" in result["workflowRunName"]

--- a/app/lambdas/tests/test_generate_wru_event_object_with_merged_data.py
+++ b/app/lambdas/tests/test_generate_wru_event_object_with_merged_data.py
@@ -1,0 +1,171 @@
+"""Tests for generate_wru_event_object_with_merged_data Lambda function.
+
+This Lambda constructs a WorkflowRunUpdate event object by merging the current
+payload data with the workflow run metadata from the API.
+"""
+
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup — mock the orcabus_api_tools.workflow layer
+# ---------------------------------------------------------------------------
+LAMBDA_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "generate_wru_event_object_with_merged_data_py"
+)
+
+_mock_api_tools = ModuleType("orcabus_api_tools")
+_mock_workflow = ModuleType("orcabus_api_tools.workflow")
+_mock_workflow.get_workflow_run_from_portal_run_id = MagicMock()
+_mock_api_tools.workflow = _mock_workflow
+
+sys.modules["orcabus_api_tools"] = _mock_api_tools
+sys.modules["orcabus_api_tools.workflow"] = _mock_workflow
+
+sys.path.insert(0, str(LAMBDA_DIR))
+
+from generate_wru_event_object_with_merged_data import handler  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_mocks():
+    """Reset mocks and set default return value."""
+    _mock_workflow.get_workflow_run_from_portal_run_id.reset_mock()
+    _mock_workflow.get_workflow_run_from_portal_run_id.return_value = {
+        "orcabusId": "wfr.abc123",
+        "portalRunId": "20250606efgh1234",
+        "workflowRunName": "umccr--automated--dragen-wgts-dna--4-4-4--20250606efgh1234",
+        "workflow": {"workflowName": "dragen-wgts-dna", "workflowVersion": "4.4.4"},
+        "linkedLibraries": [{"libraryId": "L2301197", "orcabusId": "lib.ABC123"}],
+    }
+    yield
+
+
+@pytest.mark.lambda_unit
+class TestGenerateWruEventObjectHappyPath:
+    """Test the happy path for generating a WRU event object."""
+
+    def test_output_contains_workflow_run_update(self, event_builder, lambda_context):
+        """Output should contain workflowRunUpdate key."""
+        event = event_builder({
+            "portalRunId": "20250606efgh1234",
+            "libraries": [{"libraryId": "L2301197", "orcabusId": "lib.ABC123", "readsets": []}],
+            "payload": {"version": "2025.06.04", "data": {"inputs": {}, "tags": {}}},
+        })
+
+        result = handler(event, lambda_context())
+
+        assert "workflowRunUpdate" in result
+
+    def test_orcabus_id_from_api(self, event_builder, lambda_context):
+        """The orcabusId should come from the API lookup."""
+        event = event_builder({
+            "portalRunId": "20250606efgh1234",
+            "libraries": [],
+            "payload": {"version": "2025.06.04", "data": {}},
+        })
+
+        result = handler(event, lambda_context())
+
+        assert result["workflowRunUpdate"]["orcabusId"] == "wfr.abc123"
+
+    def test_status_is_draft(self, event_builder, lambda_context):
+        """The status should always be DRAFT."""
+        event = event_builder({
+            "portalRunId": "20250606efgh1234",
+            "libraries": [],
+            "payload": {"version": "2025.06.04", "data": {}},
+        })
+
+        result = handler(event, lambda_context())
+
+        assert result["workflowRunUpdate"]["status"] == "DRAFT"
+
+    def test_workflow_preserved_from_api(self, event_builder, lambda_context):
+        """The workflow field should come from the API."""
+        event = event_builder({
+            "portalRunId": "20250606efgh1234",
+            "libraries": [],
+            "payload": {"version": "2025.06.04", "data": {}},
+        })
+
+        result = handler(event, lambda_context())
+
+        assert result["workflowRunUpdate"]["workflow"] == {
+            "workflowName": "dragen-wgts-dna",
+            "workflowVersion": "4.4.4",
+        }
+
+    def test_libraries_structured_correctly(self, event_builder, lambda_context):
+        """Libraries should be structured with libraryId, orcabusId, readsets."""
+        event = event_builder({
+            "portalRunId": "20250606efgh1234",
+            "libraries": [
+                {
+                    "libraryId": "L2301197",
+                    "orcabusId": "lib.ABC123",
+                    "readsets": [{"orcabusId": "rs.001", "rgid": "RGID001"}],
+                }
+            ],
+            "payload": {"version": "2025.06.04", "data": {}},
+        })
+
+        result = handler(event, lambda_context())
+
+        libs = result["workflowRunUpdate"]["libraries"]
+        assert len(libs) == 1
+        assert libs[0]["libraryId"] == "L2301197"
+        assert libs[0]["orcabusId"] == "lib.ABC123"
+        assert libs[0]["readsets"] == [{"orcabusId": "rs.001", "rgid": "RGID001"}]
+
+    def test_payload_passed_through(self, event_builder, lambda_context):
+        """The payload from the input should be passed through to the output."""
+        payload = {
+            "version": "2025.06.04",
+            "data": {
+                "inputs": {"sampleName": "SMP001"},
+                "tags": {"libraryId": "L2301197"},
+            },
+        }
+        event = event_builder({
+            "portalRunId": "20250606efgh1234",
+            "libraries": [],
+            "payload": payload,
+        })
+
+        result = handler(event, lambda_context())
+
+        assert result["workflowRunUpdate"]["payload"] == payload
+
+    def test_linked_libraries_from_api(self, event_builder, lambda_context):
+        """linkedLibraries should come from the API workflow run."""
+        event = event_builder({
+            "portalRunId": "20250606efgh1234",
+            "libraries": [],
+            "payload": {"version": "2025.06.04", "data": {}},
+        })
+
+        result = handler(event, lambda_context())
+
+        assert result["workflowRunUpdate"]["linkedLibraries"] == [
+            {"libraryId": "L2301197", "orcabusId": "lib.ABC123"}
+        ]
+
+    def test_portal_run_id_looked_up(self, event_builder, lambda_context):
+        """The handler should look up the workflow run by portal run ID."""
+        event = event_builder({
+            "portalRunId": "20250601test5678",
+            "libraries": [],
+            "payload": {"version": "2025.06.04", "data": {}},
+        })
+
+        handler(event, lambda_context())
+
+        _mock_workflow.get_workflow_run_from_portal_run_id.assert_called_once_with(
+            portal_run_id="20250601test5678"
+        )

--- a/app/lambdas/tests/test_get_fastq_id_list_from_rgid_list.py
+++ b/app/lambdas/tests/test_get_fastq_id_list_from_rgid_list.py
@@ -1,0 +1,106 @@
+"""Tests for get_fastq_id_list_from_rgid_list Lambda function.
+
+This Lambda converts a list of FASTQ RGIDs to their corresponding FASTQ IDs
+by looking each one up via the orcabus_api_tools.fastq API.
+"""
+
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup — mock the orcabus_api_tools.fastq layer
+# ---------------------------------------------------------------------------
+LAMBDA_DIR = Path(__file__).resolve().parents[1] / "get_fastq_id_list_from_rgid_list_py"
+
+_mock_api_tools = ModuleType("orcabus_api_tools")
+_mock_fastq = ModuleType("orcabus_api_tools.fastq")
+_mock_fastq.get_fastq_by_rgid = MagicMock()
+_mock_api_tools.fastq = _mock_fastq
+
+sys.modules["orcabus_api_tools"] = _mock_api_tools
+sys.modules["orcabus_api_tools.fastq"] = _mock_fastq
+
+sys.path.insert(0, str(LAMBDA_DIR))
+
+from get_fastq_id_list_from_rgid_list import handler  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_mocks():
+    """Reset mocks between tests."""
+    _mock_fastq.get_fastq_by_rgid.reset_mock(side_effect=True, return_value=True)
+    yield
+
+
+@pytest.mark.lambda_unit
+class TestGetFastqIdListHappyPath:
+    """Test the happy path for RGID to FASTQ ID conversion."""
+
+    def test_single_rgid(self, event_builder, lambda_context):
+        """A single RGID should return a single FASTQ ID."""
+        _mock_fastq.get_fastq_by_rgid.return_value = {
+            "id": "fqr.01K12NF97VEM0V9K0ABFAEPHNT"
+        }
+
+        event = event_builder({
+            "fastqRgidList": ["GTTCGCCG+CAATGAGC.4.250724_A01052_0269_AHFHWJDSXF"]
+        })
+
+        result = handler(event, lambda_context())
+
+        assert result == {"fastqIdList": ["fqr.01K12NF97VEM0V9K0ABFAEPHNT"]}
+
+    def test_multiple_rgids(self, event_builder, lambda_context):
+        """Multiple RGIDs should return multiple sorted FASTQ IDs."""
+        _mock_fastq.get_fastq_by_rgid.side_effect = [
+            {"id": "fqr.BBB"},
+            {"id": "fqr.AAA"},
+            {"id": "fqr.CCC"},
+        ]
+
+        event = event_builder({
+            "fastqRgidList": ["RGID1.1.RUN", "RGID2.2.RUN", "RGID3.3.RUN"]
+        })
+
+        result = handler(event, lambda_context())
+
+        # Results should be sorted
+        assert result == {"fastqIdList": ["fqr.AAA", "fqr.BBB", "fqr.CCC"]}
+
+    def test_empty_list(self, event_builder, lambda_context):
+        """An empty RGID list should return an empty FASTQ ID list."""
+        event = event_builder({"fastqRgidList": []})
+
+        result = handler(event, lambda_context())
+
+        assert result == {"fastqIdList": []}
+        _mock_fastq.get_fastq_by_rgid.assert_not_called()
+
+    def test_api_called_for_each_rgid(self, event_builder, lambda_context):
+        """The API should be called once for each RGID in the input."""
+        _mock_fastq.get_fastq_by_rgid.return_value = {"id": "fqr.TEST"}
+
+        event = event_builder({
+            "fastqRgidList": ["RGID1.1.RUN", "RGID2.2.RUN"]
+        })
+
+        handler(event, lambda_context())
+
+        assert _mock_fastq.get_fastq_by_rgid.call_count == 2
+
+
+@pytest.mark.lambda_unit
+class TestGetFastqIdListMissingKey:
+    """Test behaviour when fastqRgidList key is missing."""
+
+    def test_missing_key_defaults_to_empty(self, event_builder, lambda_context):
+        """Missing fastqRgidList should default to empty list."""
+        event = event_builder({})
+
+        result = handler(event, lambda_context())
+
+        assert result == {"fastqIdList": []}

--- a/app/lambdas/tests/test_get_fastq_list_rows_from_rgid_list.py
+++ b/app/lambdas/tests/test_get_fastq_list_rows_from_rgid_list.py
@@ -1,0 +1,163 @@
+"""Tests for get_fastq_list_rows_from_rgid_list Lambda function.
+
+This Lambda converts a list of RGIDs to FASTQ list rows (with file URIs),
+handling test-data vs non-test-data buckets and optional S3 URI prefix overrides.
+"""
+
+import os
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup — mock the orcabus_api_tools.fastq layer and requests
+# ---------------------------------------------------------------------------
+LAMBDA_DIR = Path(__file__).resolve().parents[1] / "get_fastq_list_rows_from_rgid_list_py"
+
+_mock_api_tools = ModuleType("orcabus_api_tools")
+_mock_fastq = ModuleType("orcabus_api_tools.fastq")
+_mock_fastq.get_fastq_by_rgid = MagicMock()
+_mock_fastq.to_fastq_list_row = MagicMock()
+_mock_api_tools.fastq = _mock_fastq
+
+sys.modules["orcabus_api_tools"] = _mock_api_tools
+sys.modules["orcabus_api_tools.fastq"] = _mock_fastq
+
+sys.path.insert(0, str(LAMBDA_DIR))
+
+from get_fastq_list_rows_from_rgid_list import handler  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _set_env_vars():
+    """Set required environment variables."""
+    with patch.dict(os.environ, {"TEST_DATA_BUCKET_NAME": "test-data-bucket"}):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _reset_mocks():
+    """Reset mocks between tests."""
+    _mock_fastq.get_fastq_by_rgid.reset_mock()
+    _mock_fastq.to_fastq_list_row.reset_mock()
+    yield
+
+
+@pytest.mark.lambda_unit
+class TestGetFastqListRowsHappyPath:
+    """Test the happy path for converting RGIDs to FASTQ list rows."""
+
+    @patch("get_fastq_list_rows_from_rgid_list.is_fastq_id_in_test_data_project")
+    def test_single_rgid_non_test_data(self, mock_is_test, event_builder, lambda_context):
+        """A single RGID not in test-data should use default bucket."""
+        mock_is_test.return_value = False
+        _mock_fastq.get_fastq_by_rgid.return_value = {"id": "fqr.001"}
+        _mock_fastq.to_fastq_list_row.return_value = {
+            "rgid": "RGID.1.RUN",
+            "rgsm": "SMP001",
+            "rglb": "L001",
+            "lane": 1,
+            "read1FileUri": "s3://bucket/r1.fastq.gz",
+            "read2FileUri": "s3://bucket/r2.fastq.gz",
+        }
+
+        event = event_builder({"fastqRgidList": ["RGID.1.RUN"]})
+
+        result = handler(event, lambda_context())
+
+        assert "fastqListRows" in result
+        assert len(result["fastqListRows"]) == 1
+        assert result["fastqListRows"][0]["rgid"] == "RGID.1.RUN"
+
+    @patch("get_fastq_list_rows_from_rgid_list.is_fastq_id_in_test_data_project")
+    def test_single_rgid_test_data(self, mock_is_test, event_builder, lambda_context):
+        """A single RGID in test-data should use the test bucket."""
+        mock_is_test.return_value = True
+        _mock_fastq.get_fastq_by_rgid.return_value = {"id": "fqr.001"}
+        _mock_fastq.to_fastq_list_row.return_value = {
+            "rgid": "RGID.1.RUN",
+            "rgsm": "SMP001",
+            "rglb": "L001",
+            "lane": 1,
+            "read1FileUri": "s3://test-data-bucket/r1.fastq.gz",
+            "read2FileUri": "s3://test-data-bucket/r2.fastq.gz",
+        }
+
+        event = event_builder({"fastqRgidList": ["RGID.1.RUN"]})
+
+        result = handler(event, lambda_context())
+
+        assert len(result["fastqListRows"]) == 1
+        # Verify test bucket was used
+        _mock_fastq.to_fastq_list_row.assert_called_with(
+            "fqr.001", bucket="test-data-bucket"
+        )
+
+    @patch("get_fastq_list_rows_from_rgid_list.is_fastq_id_in_test_data_project")
+    def test_with_s3_uri_prefix(self, mock_is_test, event_builder, lambda_context):
+        """A non-test RGID with s3UriPrefix should pass bucket and key_prefix."""
+        mock_is_test.return_value = False
+        _mock_fastq.get_fastq_by_rgid.return_value = {"id": "fqr.001"}
+        _mock_fastq.to_fastq_list_row.return_value = {
+            "rgid": "RGID.1.RUN",
+            "rgsm": "SMP001",
+            "rglb": "L001",
+            "lane": 1,
+            "read1FileUri": "s3://project-bucket/prefix/r1.fastq.gz",
+            "read2FileUri": "s3://project-bucket/prefix/r2.fastq.gz",
+        }
+
+        event = event_builder({
+            "fastqRgidList": ["RGID.1.RUN"],
+            "s3UriPrefix": "s3://project-bucket/prefix/path",
+        })
+
+        result = handler(event, lambda_context())
+
+        assert len(result["fastqListRows"]) == 1
+        # Verify bucket and key_prefix were passed
+        _mock_fastq.to_fastq_list_row.assert_called_with(
+            "fqr.001",
+            bucket="project-bucket",
+            key_prefix="prefix/path/",
+        )
+
+    @patch("get_fastq_list_rows_from_rgid_list.is_fastq_id_in_test_data_project")
+    def test_empty_list(self, mock_is_test, event_builder, lambda_context):
+        """An empty RGID list should return an empty fastqListRows."""
+        event = event_builder({"fastqRgidList": []})
+
+        result = handler(event, lambda_context())
+
+        assert result == {"fastqListRows": []}
+
+
+@pytest.mark.lambda_unit
+class TestGetFastqListRowsMixed:
+    """Test mixed test-data and non-test-data RGIDs."""
+
+    @patch("get_fastq_list_rows_from_rgid_list.is_fastq_id_in_test_data_project")
+    def test_mixed_test_and_non_test(self, mock_is_test, event_builder, lambda_context):
+        """A mix of test and non-test RGIDs should handle both correctly."""
+        _mock_fastq.get_fastq_by_rgid.side_effect = [
+            {"id": "fqr.test001"},
+            {"id": "fqr.prod001"},
+        ]
+        # First RGID is test data, second is not
+        mock_is_test.side_effect = [True, False]
+
+        test_row = {"rgid": "TEST.1.RUN", "rgsm": "SMP_T", "rglb": "L_T", "lane": 1,
+                    "read1FileUri": "s3://test-data-bucket/r1.fq", "read2FileUri": "s3://test-data-bucket/r2.fq"}
+        prod_row = {"rgid": "PROD.1.RUN", "rgsm": "SMP_P", "rglb": "L_P", "lane": 1,
+                    "read1FileUri": "s3://prod-bucket/r1.fq", "read2FileUri": "s3://prod-bucket/r2.fq"}
+
+        _mock_fastq.to_fastq_list_row.side_effect = [test_row, prod_row]
+
+        event = event_builder({"fastqRgidList": ["TEST.1.RUN", "PROD.1.RUN"]})
+
+        result = handler(event, lambda_context())
+
+        assert len(result["fastqListRows"]) == 2

--- a/app/lambdas/tests/test_get_fastq_rgids_from_library_id.py
+++ b/app/lambdas/tests/test_get_fastq_rgids_from_library_id.py
@@ -1,0 +1,135 @@
+"""Tests for get_fastq_rgids_from_library_id Lambda function.
+
+This Lambda retrieves FASTQ RGIDs for a given library ID by looking up the
+current FASTQ set and extracting RGIDs from the individual FASTQ objects.
+"""
+
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup — mock the orcabus_api_tools.fastq layer
+# ---------------------------------------------------------------------------
+LAMBDA_DIR = Path(__file__).resolve().parents[1] / "get_fastq_rgids_from_library_id_py"
+
+_mock_api_tools = ModuleType("orcabus_api_tools")
+_mock_fastq = ModuleType("orcabus_api_tools.fastq")
+_mock_fastq.get_fastq_sets = MagicMock()
+_mock_fastq.get_fastq_list_rows_in_fastq_set = MagicMock()
+_mock_fastq_models = ModuleType("orcabus_api_tools.fastq.models")
+_mock_fastq_models.Fastq = dict
+_mock_fastq.models = _mock_fastq_models
+_mock_api_tools.fastq = _mock_fastq
+
+sys.modules["orcabus_api_tools"] = _mock_api_tools
+sys.modules["orcabus_api_tools.fastq"] = _mock_fastq
+sys.modules["orcabus_api_tools.fastq.models"] = _mock_fastq_models
+
+sys.path.insert(0, str(LAMBDA_DIR))
+
+from get_fastq_rgids_from_library_id import handler, get_rgid_from_fastq_obj  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_mocks():
+    """Reset mocks between tests."""
+    _mock_fastq.get_fastq_sets.reset_mock()
+    _mock_fastq.get_fastq_list_rows_in_fastq_set.reset_mock()
+    yield
+
+
+@pytest.mark.lambda_unit
+class TestGetFastqRgidsHappyPath:
+    """Test the happy path for RGID retrieval."""
+
+    def test_single_lane_library(self, event_builder, lambda_context):
+        """A library with one lane should return one RGID."""
+        _mock_fastq.get_fastq_sets.return_value = [{"id": "fqset-001"}]
+        _mock_fastq.get_fastq_list_rows_in_fastq_set.return_value = [
+            {"index": "AAGTCCAA+TACTCATA", "lane": 2, "instrumentRunId": "241024_A00130_0336_BHW7MVDSXC"}
+        ]
+
+        event = event_builder({"libraryId": "L2401541"})
+
+        result = handler(event, lambda_context())
+
+        assert result == {
+            "fastqRgidList": ["AAGTCCAA+TACTCATA.2.241024_A00130_0336_BHW7MVDSXC"]
+        }
+
+    def test_multi_lane_library(self, event_builder, lambda_context):
+        """A library with multiple lanes should return multiple RGIDs."""
+        _mock_fastq.get_fastq_sets.return_value = [{"id": "fqset-002"}]
+        _mock_fastq.get_fastq_list_rows_in_fastq_set.return_value = [
+            {"index": "CAAGCTAG+CGCTATGT", "lane": 2, "instrumentRunId": "241024_A00130_0336_BHW7MVDSXC"},
+            {"index": "CAAGCTAG+CGCTATGT", "lane": 3, "instrumentRunId": "241024_A00130_0336_BHW7MVDSXC"},
+        ]
+
+        event = event_builder({"libraryId": "L2401544"})
+
+        result = handler(event, lambda_context())
+
+        assert result == {
+            "fastqRgidList": [
+                "CAAGCTAG+CGCTATGT.2.241024_A00130_0336_BHW7MVDSXC",
+                "CAAGCTAG+CGCTATGT.3.241024_A00130_0336_BHW7MVDSXC",
+            ]
+        }
+
+    def test_fastq_sets_called_with_library_id(self, event_builder, lambda_context):
+        """get_fastq_sets should be called with the correct library and currentFastqSet=True."""
+        _mock_fastq.get_fastq_sets.return_value = [{"id": "fqset-001"}]
+        _mock_fastq.get_fastq_list_rows_in_fastq_set.return_value = []
+
+        event = event_builder({"libraryId": "L2401541"})
+
+        handler(event, lambda_context())
+
+        _mock_fastq.get_fastq_sets.assert_called_once_with(
+            library="L2401541",
+            currentFastqSet=True,
+        )
+
+
+@pytest.mark.lambda_unit
+class TestGetFastqRgidsErrors:
+    """Test error handling."""
+
+    def test_no_fastq_set_found(self, event_builder, lambda_context):
+        """If no FASTQ set is found, should raise ValueError."""
+        _mock_fastq.get_fastq_sets.return_value = []
+
+        event = event_builder({"libraryId": "L_MISSING"})
+
+        with pytest.raises(ValueError, match="Expected exactly one current fastq set"):
+            handler(event, lambda_context())
+
+    def test_multiple_fastq_sets_found(self, event_builder, lambda_context):
+        """If multiple FASTQ sets are found, should raise ValueError."""
+        _mock_fastq.get_fastq_sets.return_value = [{"id": "fqset-001"}, {"id": "fqset-002"}]
+
+        event = event_builder({"libraryId": "L_MULTI"})
+
+        with pytest.raises(ValueError, match="Expected exactly one current fastq set"):
+            handler(event, lambda_context())
+
+
+@pytest.mark.lambda_unit
+class TestGetRgidFromFastqObj:
+    """Test the get_rgid_from_fastq_obj utility function."""
+
+    def test_standard_format(self):
+        """Should join index, lane, and instrumentRunId with dots."""
+        fastq_obj = {
+            "index": "AACTGAGG+AACTGAGG",
+            "lane": 1,
+            "instrumentRunId": "231010_A00130_0123_ABCDEFGHIJ",
+        }
+
+        result = get_rgid_from_fastq_obj(fastq_obj)
+
+        assert result == "AACTGAGG+AACTGAGG.1.231010_A00130_0123_ABCDEFGHIJ"

--- a/app/lambdas/tests/test_get_libraries.py
+++ b/app/lambdas/tests/test_get_libraries.py
@@ -1,0 +1,177 @@
+"""Tests for get_libraries Lambda function.
+
+This Lambda classifies libraries as tumor/normal based on metadata API lookups
+and returns structured output with library IDs and FASTQ RGIDs.
+"""
+
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup — mock the orcabus_api_tools layer
+# ---------------------------------------------------------------------------
+LAMBDA_DIR = Path(__file__).resolve().parents[1] / "get_libraries_py"
+
+_mock_api_tools = ModuleType("orcabus_api_tools")
+_mock_metadata = ModuleType("orcabus_api_tools.metadata")
+_mock_metadata.get_library_from_library_orcabus_id = MagicMock()
+_mock_api_tools.metadata = _mock_metadata
+
+_mock_models = ModuleType("orcabus_api_tools.metadata.models")
+_mock_models.LibraryBase = dict
+_mock_models.Library = dict
+_mock_metadata.models = _mock_models
+
+sys.modules["orcabus_api_tools"] = _mock_api_tools
+sys.modules["orcabus_api_tools.metadata"] = _mock_metadata
+sys.modules["orcabus_api_tools.metadata.models"] = _mock_models
+
+sys.path.insert(0, str(LAMBDA_DIR))
+
+from get_libraries import handler  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_mocks():
+    """Reset mocks between tests."""
+    _mock_metadata.get_library_from_library_orcabus_id.reset_mock()
+    yield
+
+
+def _make_library(library_id, orcabus_id, rgids):
+    """Build a library dict with readsets."""
+    return {
+        "libraryId": library_id,
+        "orcabusId": orcabus_id,
+        "readsets": [{"orcabusId": f"rs.{rgid}", "rgid": rgid} for rgid in rgids],
+    }
+
+
+def _make_library_metadata(library_id, phenotype):
+    """Build a library metadata dict as returned by the API."""
+    return {
+        "libraryId": library_id,
+        "phenotype": phenotype,
+        "type": "WGS",
+        "assay": "TsqNano",
+        "workflow": "research",
+    }
+
+
+@pytest.mark.lambda_unit
+class TestSingleLibrary:
+    """Test single library (germline) handling — no API call needed."""
+
+    def test_single_library_returns_id_and_rgids(self, event_builder, lambda_context):
+        """A single library returns its ID and FASTQ RGIDs."""
+        event = event_builder({
+            "libraries": [_make_library("L2401001", "lib.abc123", ["RGID001", "RGID002"])]
+        })
+
+        result = handler(event, lambda_context())
+
+        assert result["libraryId"] == "L2401001"
+        assert result["fastqRgidList"] == ["RGID001", "RGID002"]
+        assert "tumorLibraryId" not in result
+
+    def test_single_library_no_readsets(self, event_builder, lambda_context):
+        """A library with None readsets returns an empty RGID list."""
+        event = event_builder({
+            "libraries": [{"libraryId": "L2401001", "orcabusId": "lib.abc", "readsets": None}]
+        })
+
+        result = handler(event, lambda_context())
+
+        assert result["libraryId"] == "L2401001"
+        assert result["fastqRgidList"] == []
+
+
+@pytest.mark.lambda_unit
+class TestTumorNormalPair:
+    """Test tumor/normal pair handling — requires API lookup."""
+
+    @patch("get_libraries.get_library_from_library_orcabus_id")
+    def test_correctly_classified(self, mock_get_lib, event_builder, lambda_context):
+        """Two libraries are correctly classified by phenotype."""
+        mock_get_lib.side_effect = [
+            _make_library_metadata("L2401001", "tumor"),
+            _make_library_metadata("L2401002", "normal"),
+        ]
+
+        event = event_builder({
+            "libraries": [
+                _make_library("L2401001", "lib.tumor1", ["RGID_T1"]),
+                _make_library("L2401002", "lib.normal1", ["RGID_N1", "RGID_N2"]),
+            ]
+        })
+
+        result = handler(event, lambda_context())
+
+        assert result["libraryId"] == "L2401002"
+        assert result["tumorLibraryId"] == "L2401001"
+        assert result["fastqRgidList"] == ["RGID_N1", "RGID_N2"]
+        assert result["tumorFastqRgidList"] == ["RGID_T1"]
+
+    @patch("get_libraries.get_library_from_library_orcabus_id")
+    def test_no_tumor_raises(self, mock_get_lib, event_builder, lambda_context):
+        """If no tumor library is found, raise ValueError."""
+        mock_get_lib.side_effect = [
+            _make_library_metadata("L2401001", "normal"),
+            _make_library_metadata("L2401002", "normal"),
+        ]
+
+        event = event_builder({
+            "libraries": [
+                _make_library("L2401001", "lib.a", ["RG1"]),
+                _make_library("L2401002", "lib.b", ["RG2"]),
+            ]
+        })
+
+        with pytest.raises(ValueError, match="No tumor library found"):
+            handler(event, lambda_context())
+
+    @patch("get_libraries.get_library_from_library_orcabus_id")
+    def test_no_normal_raises(self, mock_get_lib, event_builder, lambda_context):
+        """If no normal library is found, raise ValueError."""
+        mock_get_lib.side_effect = [
+            _make_library_metadata("L2401001", "tumor"),
+            _make_library_metadata("L2401002", "tumor"),
+        ]
+
+        event = event_builder({
+            "libraries": [
+                _make_library("L2401001", "lib.a", ["RG1"]),
+                _make_library("L2401002", "lib.b", ["RG2"]),
+            ]
+        })
+
+        with pytest.raises(ValueError, match="No normal library found"):
+            handler(event, lambda_context())
+
+
+@pytest.mark.lambda_unit
+class TestInputValidation:
+    """Test input validation."""
+
+    def test_empty_libraries_raises(self, event_builder, lambda_context):
+        """Empty libraries list raises ValueError."""
+        event = event_builder({"libraries": []})
+
+        with pytest.raises(ValueError, match="No libraries provided"):
+            handler(event, lambda_context())
+
+    def test_too_many_libraries_raises(self, event_builder, lambda_context):
+        """More than two libraries raises ValueError."""
+        event = event_builder({
+            "libraries": [
+                _make_library(f"L24010{i}", f"lib.{i}", [f"RG{i}"])
+                for i in range(3)
+            ]
+        })
+
+        with pytest.raises(ValueError, match="at most two libraries"):
+            handler(event, lambda_context())

--- a/app/lambdas/tests/test_get_metadata_tags.py
+++ b/app/lambdas/tests/test_get_metadata_tags.py
@@ -1,0 +1,99 @@
+"""Tests for get_metadata_tags Lambda function.
+
+This Lambda retrieves library metadata from the OrcaBus Metadata API
+given a library ID. It's a simple pass-through wrapper.
+"""
+
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup — mock the orcabus_api_tools.metadata layer
+# ---------------------------------------------------------------------------
+LAMBDA_DIR = Path(__file__).resolve().parents[1] / "get_metadata_tags_py"
+
+_mock_api_tools = ModuleType("orcabus_api_tools")
+_mock_metadata = ModuleType("orcabus_api_tools.metadata")
+_mock_metadata.get_library_from_library_id = MagicMock()
+_mock_api_tools.metadata = _mock_metadata
+
+sys.modules["orcabus_api_tools"] = _mock_api_tools
+sys.modules["orcabus_api_tools.metadata"] = _mock_metadata
+
+sys.path.insert(0, str(LAMBDA_DIR))
+
+from get_metadata_tags import handler  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_mocks():
+    """Reset mocks between tests."""
+    _mock_metadata.get_library_from_library_id.reset_mock()
+    yield
+
+
+@pytest.mark.lambda_unit
+class TestGetMetadataTagsHappyPath:
+    """Test the happy path for metadata tag retrieval."""
+
+    def test_returns_library_obj(self, event_builder, lambda_context):
+        """Handler should return the libraryObj from the API."""
+        expected_lib = {
+            "libraryId": "L2401001",
+            "phenotype": "tumor",
+            "type": "WGS",
+            "assay": "TsqNano",
+            "workflow": "clinical",
+            "subject": {"subjectId": "SBJ001"},
+        }
+        _mock_metadata.get_library_from_library_id.return_value = expected_lib
+
+        event = event_builder({"libraryId": "L2401001"})
+
+        result = handler(event, lambda_context())
+
+        assert result == {"libraryObj": expected_lib}
+
+    def test_api_called_with_library_id(self, event_builder, lambda_context):
+        """The API should be called with the provided library ID."""
+        _mock_metadata.get_library_from_library_id.return_value = {"libraryId": "L2401002"}
+
+        event = event_builder({"libraryId": "L2401002"})
+
+        handler(event, lambda_context())
+
+        _mock_metadata.get_library_from_library_id.assert_called_once_with("L2401002")
+
+    def test_different_library_metadata(self, event_builder, lambda_context):
+        """Should correctly return metadata for different library types."""
+        expected_lib = {
+            "libraryId": "L2401003",
+            "phenotype": "normal",
+            "type": "WGS",
+            "assay": "TsqNano",
+            "workflow": "research",
+        }
+        _mock_metadata.get_library_from_library_id.return_value = expected_lib
+
+        event = event_builder({"libraryId": "L2401003"})
+
+        result = handler(event, lambda_context())
+
+        assert result["libraryObj"]["phenotype"] == "normal"
+        assert result["libraryObj"]["workflow"] == "research"
+
+
+@pytest.mark.lambda_unit
+class TestGetMetadataTagsErrors:
+    """Test error handling."""
+
+    def test_missing_library_id_raises(self, event_builder, lambda_context):
+        """Missing libraryId key should raise KeyError."""
+        event = event_builder({})
+
+        with pytest.raises(KeyError):
+            handler(event, lambda_context())

--- a/app/lambdas/tests/test_get_missing_schema_fields.py
+++ b/app/lambdas/tests/test_get_missing_schema_fields.py
@@ -1,0 +1,208 @@
+"""Tests for get_missing_schema_fields Lambda function.
+
+This Lambda validates payload data against a JSON schema and returns the list
+of missing/invalid fields. It fetches the schema from AWS (SSM + Schema Registry),
+which we patch here.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup
+# ---------------------------------------------------------------------------
+LAMBDA_DIR = Path(__file__).resolve().parents[1] / "get_missing_schema_fields_py"
+
+sys.path.insert(0, str(LAMBDA_DIR))
+
+from get_missing_schema_fields import handler  # noqa: E402
+
+# Sample schema for tests
+SAMPLE_SCHEMA = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "required": ["sampleName", "reference", "sequenceData"],
+    "properties": {
+        "sampleName": {"type": "string", "minLength": 1},
+        "reference": {
+            "type": "object",
+            "required": ["name", "tarball"],
+            "properties": {
+                "name": {"type": "string"},
+                "tarball": {"type": "string", "pattern": "^s3://"},
+            },
+        },
+        "sequenceData": {
+            "type": "object",
+            "required": ["fastqListRows"],
+            "properties": {
+                "fastqListRows": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "required": ["rgid", "read1FileUri"],
+                        "properties": {
+                            "rgid": {"type": "string"},
+                            "read1FileUri": {"type": "string", "pattern": "^s3://"},
+                        },
+                    },
+                }
+            },
+        },
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def _set_env_vars():
+    """Set required environment variables."""
+    env_vars = {
+        "SSM_REGISTRY_NAME": "/orcabus/schemas/registry-name",
+        "SSM_SCHEMA_PATH": "/orcabus/workflows/dragen-wgts-dna/schema",
+        "DEFAULT_PAYLOAD_VERSION": "2025.06.04",
+    }
+    with patch.dict(os.environ, env_vars):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _mock_aws():
+    """Patch SSM and Schema Registry calls."""
+    def ssm_side_effect(parameter_name):
+        params = {
+            "/orcabus/schemas/registry-name": "OrcaBusSchemaRegistry",
+            "/orcabus/workflows/dragen-wgts-dna/schema/2025.06.04": json.dumps(
+                {"schemaName": "dragen-wgts-dna-draft-v2025.06.04"}
+            ),
+        }
+        if parameter_name in params:
+            return params[parameter_name]
+        raise ValueError(f"Unknown SSM parameter: {parameter_name}")
+
+    with (
+        patch("get_missing_schema_fields.get_ssm_parameter_value", side_effect=ssm_side_effect),
+        patch(
+            "get_missing_schema_fields.get_schema_from_registry",
+            return_value=json.dumps(SAMPLE_SCHEMA),
+        ),
+    ):
+        yield
+
+
+@pytest.mark.lambda_unit
+class TestGetMissingSchemaFieldsValid:
+    """Test cases where the payload is valid — no missing fields."""
+
+    def test_complete_payload_no_missing_fields(self, event_builder, lambda_context):
+        """A fully valid payload should return an empty missingFields list."""
+        event = event_builder({
+            "payloadVersion": "2025.06.04",
+            "data": {
+                "sampleName": "SMP001",
+                "reference": {"name": "hg38", "tarball": "s3://bucket/ref.tar.gz"},
+                "sequenceData": {
+                    "fastqListRows": [
+                        {"rgid": "RGID001", "read1FileUri": "s3://bucket/r1.fq.gz"}
+                    ]
+                },
+            },
+        })
+
+        result = handler(event, lambda_context())
+
+        assert result["missingFields"] == []
+
+
+@pytest.mark.lambda_unit
+class TestGetMissingSchemaFieldsMissing:
+    """Test cases where the payload is missing required fields."""
+
+    def test_missing_top_level_field(self, event_builder, lambda_context):
+        """Missing 'sampleName' should appear in missingFields."""
+        event = event_builder({
+            "payloadVersion": "2025.06.04",
+            "data": {
+                # Missing sampleName
+                "reference": {"name": "hg38", "tarball": "s3://bucket/ref.tar.gz"},
+                "sequenceData": {
+                    "fastqListRows": [
+                        {"rgid": "RGID001", "read1FileUri": "s3://bucket/r1.fq.gz"}
+                    ]
+                },
+            },
+        })
+
+        result = handler(event, lambda_context())
+
+        assert any("sampleName" in f for f in result["missingFields"])
+
+    def test_missing_nested_field(self, event_builder, lambda_context):
+        """Missing 'reference.tarball' should appear in missingFields."""
+        event = event_builder({
+            "payloadVersion": "2025.06.04",
+            "data": {
+                "sampleName": "SMP001",
+                "reference": {"name": "hg38"},  # Missing tarball
+                "sequenceData": {
+                    "fastqListRows": [
+                        {"rgid": "RGID001", "read1FileUri": "s3://bucket/r1.fq.gz"}
+                    ]
+                },
+            },
+        })
+
+        result = handler(event, lambda_context())
+
+        assert any("tarball" in f for f in result["missingFields"])
+
+    def test_missing_multiple_fields(self, event_builder, lambda_context):
+        """Multiple missing fields should all be reported."""
+        event = event_builder({
+            "payloadVersion": "2025.06.04",
+            "data": {},  # Missing everything
+        })
+
+        result = handler(event, lambda_context())
+
+        assert len(result["missingFields"]) >= 3  # sampleName, reference, sequenceData
+
+    def test_invalid_type_reported(self, event_builder, lambda_context):
+        """A wrong type should be reported in missingFields."""
+        event = event_builder({
+            "payloadVersion": "2025.06.04",
+            "data": {
+                "sampleName": 123,  # Should be string
+                "reference": {"name": "hg38", "tarball": "s3://bucket/ref.tar.gz"},
+                "sequenceData": {
+                    "fastqListRows": [
+                        {"rgid": "RGID001", "read1FileUri": "s3://bucket/r1.fq.gz"}
+                    ]
+                },
+            },
+        })
+
+        result = handler(event, lambda_context())
+
+        # Should report the type error for sampleName
+        assert len(result["missingFields"]) > 0
+
+    def test_empty_fastq_list_rows(self, event_builder, lambda_context):
+        """An empty fastqListRows array should trigger a validation error."""
+        event = event_builder({
+            "payloadVersion": "2025.06.04",
+            "data": {
+                "sampleName": "SMP001",
+                "reference": {"name": "hg38", "tarball": "s3://bucket/ref.tar.gz"},
+                "sequenceData": {"fastqListRows": []},  # minItems = 1
+            },
+        })
+
+        result = handler(event, lambda_context())
+
+        assert len(result["missingFields"]) > 0

--- a/app/lambdas/tests/test_get_project_base_uri_from_project_id.py
+++ b/app/lambdas/tests/test_get_project_base_uri_from_project_id.py
@@ -1,0 +1,101 @@
+"""Tests for get_project_base_uri_from_project_id Lambda function.
+
+This Lambda retrieves the S3 base URI for an ICAv2 project by its project ID.
+It uses wrapica and icav2_tools layers.
+"""
+
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup — mock wrapica and icav2_tools layers
+# ---------------------------------------------------------------------------
+LAMBDA_DIR = Path(__file__).resolve().parents[1] / "get_project_base_uri_from_project_id_py"
+
+# Mock wrapica
+_mock_wrapica = ModuleType("wrapica")
+_mock_storage_config = ModuleType("wrapica.storage_configuration")
+_mock_storage_config.get_s3_key_prefix_by_project_id = MagicMock()
+_mock_wrapica.storage_configuration = _mock_storage_config
+
+# Mock icav2_tools
+_mock_icav2_tools = ModuleType("icav2_tools")
+_mock_icav2_tools.set_icav2_env_vars = MagicMock()
+
+sys.modules["wrapica"] = _mock_wrapica
+sys.modules["wrapica.storage_configuration"] = _mock_storage_config
+sys.modules["icav2_tools"] = _mock_icav2_tools
+
+sys.path.insert(0, str(LAMBDA_DIR))
+
+from get_project_base_uri_from_project_id import handler  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_mocks():
+    """Reset mocks between tests."""
+    _mock_storage_config.get_s3_key_prefix_by_project_id.reset_mock()
+    _mock_icav2_tools.set_icav2_env_vars.reset_mock()
+    yield
+
+
+@pytest.mark.lambda_unit
+class TestGetProjectBaseUriHappyPath:
+    """Test the happy path for project base URI retrieval."""
+
+    def test_returns_s3_uri(self, event_builder, lambda_context):
+        """Handler should return the S3 URI for the given project."""
+        _mock_storage_config.get_s3_key_prefix_by_project_id.return_value = (
+            "s3://project-data-bucket/byob-icav2/project-wgs/"
+        )
+
+        event = event_builder({"projectId": "ea19a3f5-ec7c-4940-a474-c31cd91dbad4"})
+
+        result = handler(event, lambda_context())
+
+        assert result == {"s3Uri": "s3://project-data-bucket/byob-icav2/project-wgs/"}
+
+    def test_calls_wrapica_with_project_id(self, event_builder, lambda_context):
+        """Should call get_s3_key_prefix_by_project_id with the correct project ID."""
+        _mock_storage_config.get_s3_key_prefix_by_project_id.return_value = "s3://bucket/prefix/"
+
+        event = event_builder({"projectId": "test-project-id-123"})
+
+        handler(event, lambda_context())
+
+        _mock_storage_config.get_s3_key_prefix_by_project_id.assert_called_once_with(
+            "test-project-id-123"
+        )
+
+    def test_sets_icav2_env_vars(self, event_builder, lambda_context):
+        """Should call set_icav2_env_vars before making the API call."""
+        _mock_storage_config.get_s3_key_prefix_by_project_id.return_value = "s3://bucket/prefix/"
+
+        event = event_builder({"projectId": "proj-456"})
+
+        handler(event, lambda_context())
+
+        _mock_icav2_tools.set_icav2_env_vars.assert_called_once()
+
+
+@pytest.mark.lambda_unit
+class TestGetProjectBaseUriErrors:
+    """Test error handling."""
+
+    def test_missing_project_id_raises(self, event_builder, lambda_context):
+        """Missing projectId should raise ValueError."""
+        event = event_builder({})
+
+        with pytest.raises(ValueError, match="projectId is a required input"):
+            handler(event, lambda_context())
+
+    def test_none_project_id_raises(self, event_builder, lambda_context):
+        """None projectId should raise ValueError."""
+        event = event_builder({"projectId": None})
+
+        with pytest.raises(ValueError, match="projectId is a required input"):
+            handler(event, lambda_context())

--- a/app/lambdas/tests/test_get_qc_summary_stats_from_rgid_list.py
+++ b/app/lambdas/tests/test_get_qc_summary_stats_from_rgid_list.py
@@ -1,0 +1,134 @@
+"""Tests for get_qc_summary_stats_from_rgid_list Lambda function.
+
+This Lambda collects QC summary stats (coverage, duplication fraction, insert size)
+from FASTQ objects by RGID, then sums/averages them.
+"""
+
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup — mock the orcabus_api_tools.fastq layer
+# ---------------------------------------------------------------------------
+LAMBDA_DIR = Path(__file__).resolve().parents[1] / "get_qc_summary_stats_from_rgid_list_py"
+
+_mock_api_tools = ModuleType("orcabus_api_tools")
+_mock_fastq = ModuleType("orcabus_api_tools.fastq")
+_mock_fastq.get_fastq_by_rgid = MagicMock()
+_mock_fastq_models = ModuleType("orcabus_api_tools.fastq.models")
+_mock_fastq_models.Fastq = dict
+_mock_fastq.models = _mock_fastq_models
+_mock_api_tools.fastq = _mock_fastq
+
+sys.modules["orcabus_api_tools"] = _mock_api_tools
+sys.modules["orcabus_api_tools.fastq"] = _mock_fastq
+sys.modules["orcabus_api_tools.fastq.models"] = _mock_fastq_models
+
+sys.path.insert(0, str(LAMBDA_DIR))
+
+from get_qc_summary_stats_from_rgid_list import handler  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_mocks():
+    """Reset mocks between tests."""
+    _mock_fastq.get_fastq_by_rgid.reset_mock()
+    yield
+
+
+def _make_fastq_obj(coverage, dup_frac, insert_size):
+    """Build a FASTQ object with QC stats."""
+    return {
+        "qc": {
+            "rawWgsCoverageEstimate": coverage,
+            "duplicationFractionEstimate": dup_frac,
+            "insertSizeEstimate": insert_size,
+        }
+    }
+
+
+@pytest.mark.lambda_unit
+class TestGetQcSummaryStatsHappyPath:
+    """Test the happy path for QC stat aggregation."""
+
+    def test_single_rgid(self, event_builder, lambda_context):
+        """A single RGID should return its stats directly."""
+        _mock_fastq.get_fastq_by_rgid.return_value = _make_fastq_obj(30.5, 0.12, 350.0)
+
+        event = event_builder({"fastqRgidList": ["RGID.1.RUN"]})
+
+        result = handler(event, lambda_context())
+
+        assert result["coverageSum"] == 30.5
+        assert result["dupFracAvg"] == 0.12
+        assert result["insertSizeAvg"] == 350.0
+
+    def test_multiple_rgids_summed_and_averaged(self, event_builder, lambda_context):
+        """Multiple RGIDs should sum coverage and average dup/insert."""
+        _mock_fastq.get_fastq_by_rgid.side_effect = [
+            _make_fastq_obj(30.0, 0.10, 300.0),
+            _make_fastq_obj(20.0, 0.20, 400.0),
+        ]
+
+        event = event_builder({"fastqRgidList": ["RGID.1.RUN", "RGID.2.RUN"]})
+
+        result = handler(event, lambda_context())
+
+        assert result["coverageSum"] == 50.0  # 30 + 20
+        assert result["dupFracAvg"] == 0.15   # (0.10 + 0.20) / 2
+        assert result["insertSizeAvg"] == 350.0  # (300 + 400) / 2
+
+    def test_three_rgids(self, event_builder, lambda_context):
+        """Three RGIDs should correctly sum and average."""
+        _mock_fastq.get_fastq_by_rgid.side_effect = [
+            _make_fastq_obj(10.0, 0.10, 300.0),
+            _make_fastq_obj(20.0, 0.20, 350.0),
+            _make_fastq_obj(30.0, 0.30, 400.0),
+        ]
+
+        event = event_builder({"fastqRgidList": ["RG1.1.R", "RG2.2.R", "RG3.3.R"]})
+
+        result = handler(event, lambda_context())
+
+        assert result["coverageSum"] == 60.0  # 10 + 20 + 30
+        assert result["dupFracAvg"] == 0.2    # (0.1 + 0.2 + 0.3) / 3
+        assert result["insertSizeAvg"] == 350.0  # (300 + 350 + 400) / 3
+
+
+@pytest.mark.lambda_unit
+class TestGetQcSummaryStatsEmptyInput:
+    """Test behaviour with empty RGID list."""
+
+    def test_empty_list_returns_negative_one(self, event_builder, lambda_context):
+        """An empty RGID list should return -1 for all stats."""
+        event = event_builder({"fastqRgidList": []})
+
+        result = handler(event, lambda_context())
+
+        assert result["coverageSum"] == -1
+        assert result["dupFracAvg"] == -1
+        assert result["insertSizeAvg"] == -1
+
+
+@pytest.mark.lambda_unit
+class TestGetQcSummaryStatsRounding:
+    """Test that results are rounded to 2 decimal places."""
+
+    def test_values_rounded_to_2dp(self, event_builder, lambda_context):
+        """Results should be rounded to 2 decimal places."""
+        _mock_fastq.get_fastq_by_rgid.side_effect = [
+            _make_fastq_obj(10.123456, 0.123456, 333.333333),
+            _make_fastq_obj(20.654321, 0.654321, 666.666666),
+        ]
+
+        event = event_builder({"fastqRgidList": ["RG1.1.R", "RG2.2.R"]})
+
+        result = handler(event, lambda_context())
+
+        assert result["coverageSum"] == 30.78  # round(30.777777, 2)
+        assert result["dupFracAvg"] == 0.39    # round(0.388888, 2)
+        assert result["insertSizeAvg"] == 500.0  # round(500.0, 2)

--- a/app/lambdas/tests/test_post_schema_validation.py
+++ b/app/lambdas/tests/test_post_schema_validation.py
@@ -1,0 +1,197 @@
+"""Tests for post_schema_validation Lambda function.
+
+This Lambda performs post-schema validation: checking that input URIs exist and
+are accessible in the correct ICAv2 project context, and validating clinical
+sample coverage thresholds. It uses multiple external services (ICAv2, OrcaBus APIs,
+Filemanager) which we mock here.
+"""
+
+import os
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup — mock all external layers before importing
+# ---------------------------------------------------------------------------
+LAMBDA_DIR = Path(__file__).resolve().parents[1] / "post_schema_validation_py"
+
+# Mock wrapica
+_mock_wrapica = ModuleType("wrapica")
+_mock_project_data = ModuleType("wrapica.project_data")
+_mock_project_data.coerce_data_id_or_uri_to_project_data_obj = MagicMock()
+_mock_project_data.get_project_data_obj_by_id = MagicMock()
+_mock_storage_config = ModuleType("wrapica.storage_configuration")
+_mock_storage_config.get_s3_key_prefix_by_project_id = MagicMock()
+_mock_project_pipelines = ModuleType("wrapica.project_pipelines")
+_mock_project_pipelines.get_project_pipeline_obj = MagicMock()
+_mock_project = ModuleType("wrapica.project")
+_mock_project.get_project_obj_from_project_id = MagicMock()
+_mock_wrapica.project_data = _mock_project_data
+_mock_wrapica.storage_configuration = _mock_storage_config
+_mock_wrapica.project_pipelines = _mock_project_pipelines
+_mock_wrapica.project = _mock_project
+
+# Mock libica
+_mock_libica = ModuleType("libica")
+_mock_libica_openapi = ModuleType("libica.openapi")
+_mock_libica_v3 = ModuleType("libica.openapi.v3")
+_mock_libica_v3.ApiException = type("ApiException", (Exception,), {})
+_mock_libica.openapi = _mock_libica_openapi
+_mock_libica_openapi.v3 = _mock_libica_v3
+
+# Mock icav2_tools
+_mock_icav2_tools = ModuleType("icav2_tools")
+_mock_icav2_tools.set_icav2_env_vars = MagicMock()
+
+# Mock orcabus_api_tools
+_mock_api_tools = ModuleType("orcabus_api_tools")
+_mock_workflow = ModuleType("orcabus_api_tools.workflow")
+_mock_workflow.add_comment_to_workflow_run = MagicMock()
+_mock_workflow.get_workflow_run = MagicMock()
+_mock_metadata = ModuleType("orcabus_api_tools.metadata")
+_mock_metadata.get_library_from_library_id = MagicMock()
+_mock_filemanager = ModuleType("orcabus_api_tools.filemanager")
+_mock_filemanager.get_s3_object_id_from_s3_uri = MagicMock()
+_mock_filemanager.list_files_recursively = MagicMock()
+_mock_filemanager_errors = ModuleType("orcabus_api_tools.filemanager.errors")
+_mock_filemanager_errors.S3FileNotFoundError = type("S3FileNotFoundError", (Exception,), {})
+_mock_filemanager.errors = _mock_filemanager_errors
+_mock_api_tools.workflow = _mock_workflow
+_mock_api_tools.metadata = _mock_metadata
+_mock_api_tools.filemanager = _mock_filemanager
+
+sys.modules["wrapica"] = _mock_wrapica
+sys.modules["wrapica.project_data"] = _mock_project_data
+sys.modules["wrapica.storage_configuration"] = _mock_storage_config
+sys.modules["wrapica.project_pipelines"] = _mock_project_pipelines
+sys.modules["wrapica.project"] = _mock_project
+sys.modules["libica"] = _mock_libica
+sys.modules["libica.openapi"] = _mock_libica_openapi
+sys.modules["libica.openapi.v3"] = _mock_libica_v3
+sys.modules["icav2_tools"] = _mock_icav2_tools
+sys.modules["orcabus_api_tools"] = _mock_api_tools
+sys.modules["orcabus_api_tools.workflow"] = _mock_workflow
+sys.modules["orcabus_api_tools.metadata"] = _mock_metadata
+sys.modules["orcabus_api_tools.filemanager"] = _mock_filemanager
+sys.modules["orcabus_api_tools.filemanager.errors"] = _mock_filemanager_errors
+
+# Set env vars BEFORE importing (handler reads them at module level)
+os.environ.setdefault("WORKFLOW_NAME", "dragen-wgts-dna")
+os.environ.setdefault("TEST_DATA_BUCKET_NAME", "test-data-bucket")
+os.environ.setdefault("REF_DATA_BUCKET_NAME", "ref-data-bucket")
+os.environ.setdefault("MIN_RAW_TUMOR_WGS_COVERAGE", "60")
+os.environ.setdefault("MIN_DEDUP_TUMOR_WGS_COVERAGE", "50")
+os.environ.setdefault("MIN_RAW_NORMAL_WGS_COVERAGE", "30")
+os.environ.setdefault("MIN_DEDUP_NORMAL_WGS_COVERAGE", "25")
+
+sys.path.insert(0, str(LAMBDA_DIR))
+
+from post_schema_validation import handler  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_mocks():
+    """Reset all mocks between tests."""
+    _mock_storage_config.get_s3_key_prefix_by_project_id.reset_mock()
+    _mock_project.get_project_obj_from_project_id.reset_mock()
+    _mock_project_pipelines.get_project_pipeline_obj.reset_mock()
+    _mock_workflow.add_comment_to_workflow_run.reset_mock()
+    _mock_workflow.get_workflow_run.reset_mock()
+    _mock_filemanager.get_s3_object_id_from_s3_uri.reset_mock()
+    _mock_filemanager.list_files_recursively.reset_mock()
+    _mock_metadata.get_library_from_library_id.reset_mock()
+    _mock_icav2_tools.set_icav2_env_vars.reset_mock()
+
+    # Default mock return values
+    _mock_storage_config.get_s3_key_prefix_by_project_id.return_value = (
+        "s3://project-bucket/byob-icav2/project/"
+    )
+    _mock_project.get_project_obj_from_project_id.return_value = {"id": "proj-456"}
+    _mock_project_pipelines.get_project_pipeline_obj.return_value = {"id": "pipe-123"}
+    _mock_workflow.get_workflow_run.return_value = {
+        "portalRunId": "20250606abcd1234",  # pragma: allowlist secret
+        "workflowRunName": "umccr--automated--dragen-wgts-dna--4-4-4--20250606abcd1234",
+    }
+    _mock_filemanager.get_s3_object_id_from_s3_uri.return_value = {"s3ObjectId": "obj-123"}
+    yield
+
+
+def _make_valid_event():
+    """Build a minimal valid event for post_schema_validation."""
+    return {
+        "workflowRunId": "wfr.abc123",
+        "executionArn": "arn:aws:states:ap-southeast-2:123456:execution:sfn:exec-1",
+        "data": {
+            "inputs": {
+                "sampleName": "L2301197",
+                "reference": {"name": "hg38", "structure": "linear", "tarball": "s3://ref-data-bucket/hg38.tar.gz"},
+                "sequenceData": {
+                    "fastqListRows": [
+                        {"rgid": "RG1", "read1FileUri": "s3://project-bucket/byob-icav2/project/r1.fq", "read2FileUri": "s3://project-bucket/byob-icav2/project/r2.fq"}
+                    ]
+                },
+            },
+            "engineParameters": {
+                "projectId": "proj-456",
+                "pipelineId": "pipe-123",
+                "outputUri": "s3://project-bucket/byob-icav2/project/analysis/dragen-wgts-dna/20250606abcd1234/",
+                "logsUri": "s3://project-bucket/byob-icav2/project/logs/dragen-wgts-dna/20250606abcd1234/",
+            },
+            "tags": {"libraryId": "L2301197"},
+        },
+    }
+
+
+@pytest.mark.lambda_unit
+class TestPostSchemaValidationValid:
+    """Test cases where the post-schema validation passes."""
+
+    def test_valid_germline_event(self, event_builder, lambda_context):
+        """A valid germline event should return isValid=True."""
+        event = event_builder(_make_valid_event())
+
+        result = handler(event, lambda_context())
+
+        assert result == {"isValid": True}
+
+    def test_sets_icav2_env_vars(self, event_builder, lambda_context):
+        """Should call set_icav2_env_vars."""
+        event = event_builder(_make_valid_event())
+
+        handler(event, lambda_context())
+
+        _mock_icav2_tools.set_icav2_env_vars.assert_called_once()
+
+
+@pytest.mark.lambda_unit
+class TestPostSchemaValidationEngineParameterErrors:
+    """Test engine parameter validation failures."""
+
+    def test_invalid_output_uri_prefix(self, event_builder, lambda_context):
+        """OutputUri not in project prefix should fail validation."""
+        event_data = _make_valid_event()
+        event_data["data"]["engineParameters"]["outputUri"] = (
+            "s3://wrong-bucket/analysis/dragen-wgts-dna/20250606abcd1234/"
+        )
+        event = event_builder(event_data)
+
+        result = handler(event, lambda_context())
+
+        assert result == {"isValid": False}
+        _mock_workflow.add_comment_to_workflow_run.assert_called()
+
+    def test_invalid_logs_uri_prefix(self, event_builder, lambda_context):
+        """LogsUri not in project prefix should fail validation."""
+        event_data = _make_valid_event()
+        event_data["data"]["engineParameters"]["logsUri"] = (
+            "s3://wrong-bucket/logs/dragen-wgts-dna/20250606abcd1234/"
+        )
+        event = event_builder(event_data)
+
+        result = handler(event, lambda_context())
+
+        assert result == {"isValid": False}

--- a/app/lambdas/tests/test_validate_draft_complete_schema.py
+++ b/app/lambdas/tests/test_validate_draft_complete_schema.py
@@ -1,0 +1,289 @@
+"""Tests for validate_draft_complete_schema Lambda function.
+
+This Lambda validates a draft payload against a JSON schema fetched from
+AWS Schema Registry. We patch the SSM and Schema Registry calls.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup — mock the orcabus_api_tools and boto3 layers
+# ---------------------------------------------------------------------------
+LAMBDA_DIR = Path(__file__).resolve().parents[1] / "validate_draft_complete_schema_py"
+
+_mock_api_tools = ModuleType("orcabus_api_tools")
+_mock_workflow = ModuleType("orcabus_api_tools.workflow")
+_mock_workflow.add_comment_to_workflow_run = MagicMock()
+_mock_api_tools.workflow = _mock_workflow
+
+sys.modules["orcabus_api_tools"] = _mock_api_tools
+sys.modules["orcabus_api_tools.workflow"] = _mock_workflow
+
+sys.path.insert(0, str(LAMBDA_DIR))
+
+from validate_draft_complete_schema import handler  # noqa: E402
+
+
+# Test JSON schema
+SAMPLE_SCHEMA = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "required": ["sampleId", "libraryId", "fastqListRows"],
+    "properties": {
+        "sampleId": {"type": "string", "minLength": 1},
+        "libraryId": {"type": "string", "minLength": 1},
+        "fastqListRows": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "object",
+                "required": ["rgid", "rgsm", "lane", "read1FileUri"],
+                "properties": {
+                    "rgid": {"type": "string"},
+                    "rgsm": {"type": "string"},
+                    "lane": {"type": "integer", "minimum": 1},
+                    "read1FileUri": {"type": "string", "pattern": "^s3://"},
+                },
+            },
+        },
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def _set_env_vars():
+    """Set required environment variables."""
+    env_vars = {
+        "SSM_REGISTRY_NAME": "/orcabus/schemas/registry-name",
+        "SSM_SCHEMA_PATH": "/orcabus/workflows/dragen-wgts-dna/schema",
+        "WORKFLOW_NAME": "dragen-wgts-dna",
+        "DEFAULT_PAYLOAD_VERSION": "2025.06.04",
+    }
+    with patch.dict(os.environ, env_vars):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _mock_aws():
+    """Patch AWS service calls."""
+    def ssm_side_effect(parameter_name):
+        params = {
+            "/orcabus/schemas/registry-name": "OrcaBusSchemaRegistry",
+            "/orcabus/workflows/dragen-wgts-dna/schema/2025.06.04": json.dumps(
+                {"schemaName": "dragen-wgts-dna-draft-v2025.06.04"}
+            ),
+        }
+        if parameter_name in params:
+            return params[parameter_name]
+        raise ValueError(f"Unknown SSM parameter: {parameter_name}")
+
+    with (
+        patch(
+            "validate_draft_complete_schema.get_ssm_parameter_value",
+            side_effect=ssm_side_effect,
+        ),
+        patch(
+            "validate_draft_complete_schema.get_schema_from_registry",
+            return_value=json.dumps(SAMPLE_SCHEMA),
+        ),
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _reset_mocks():
+    """Reset comment mock between tests."""
+    _mock_workflow.add_comment_to_workflow_run.reset_mock()
+    yield
+
+
+@pytest.fixture()
+def mock_add_comment():
+    """Patch the add_comment_to_workflow_run at the handler module level."""
+    with patch("validate_draft_complete_schema.add_comment_to_workflow_run") as mock_comment:
+        yield mock_comment
+
+
+@pytest.mark.lambda_unit
+class TestValidateValidPayloads:
+    """Test that valid payloads pass validation."""
+
+    def test_valid_minimal_payload(self, event_builder, lambda_context):
+        """A payload with all required fields passes validation."""
+        event = event_builder({
+            "payloadVersion": "2025.06.04",
+            "data": {
+                "sampleId": "SMP001",
+                "libraryId": "L2401001",
+                "fastqListRows": [
+                    {
+                        "rgid": "RGID001.1.RUN",
+                        "rgsm": "SMP001",
+                        "lane": 1,
+                        "read1FileUri": "s3://bucket/r1.fastq.gz",
+                    }
+                ],
+            },
+        })
+
+        result = handler(event, lambda_context())
+
+        assert result == {"isValid": True}
+
+    def test_valid_multiple_rows(self, event_builder, lambda_context):
+        """A payload with multiple FASTQ rows passes validation."""
+        event = event_builder({
+            "payloadVersion": "2025.06.04",
+            "data": {
+                "sampleId": "SMP001",
+                "libraryId": "L2401001",
+                "fastqListRows": [
+                    {"rgid": "RG1", "rgsm": "SMP001", "lane": 1, "read1FileUri": "s3://b/r1.fq"},
+                    {"rgid": "RG2", "rgsm": "SMP001", "lane": 2, "read1FileUri": "s3://b/r2.fq"},
+                ],
+            },
+        })
+
+        result = handler(event, lambda_context())
+
+        assert result == {"isValid": True}
+
+
+@pytest.mark.lambda_unit
+class TestValidateInvalidPayloads:
+    """Test that invalid payloads fail validation."""
+
+    def test_missing_required_field(self, event_builder, lambda_context):
+        """Missing 'sampleId' should fail validation."""
+        event = event_builder({
+            "payloadVersion": "2025.06.04",
+            "data": {
+                "libraryId": "L2401001",
+                "fastqListRows": [
+                    {"rgid": "RG1", "rgsm": "SMP001", "lane": 1, "read1FileUri": "s3://b/r1.fq"}
+                ],
+            },
+        })
+
+        result = handler(event, lambda_context())
+
+        assert result == {"isValid": False}
+
+    def test_wrong_type_for_lane(self, event_builder, lambda_context):
+        """String lane instead of integer should fail validation."""
+        event = event_builder({
+            "payloadVersion": "2025.06.04",
+            "data": {
+                "sampleId": "SMP001",
+                "libraryId": "L2401001",
+                "fastqListRows": [
+                    {"rgid": "RG1", "rgsm": "SMP001", "lane": "one", "read1FileUri": "s3://b/r1.fq"}
+                ],
+            },
+        })
+
+        result = handler(event, lambda_context())
+
+        assert result == {"isValid": False}
+
+    def test_empty_fastq_list(self, event_builder, lambda_context):
+        """Empty fastqListRows should fail minItems validation."""
+        event = event_builder({
+            "payloadVersion": "2025.06.04",
+            "data": {
+                "sampleId": "SMP001",
+                "libraryId": "L2401001",
+                "fastqListRows": [],
+            },
+        })
+
+        result = handler(event, lambda_context())
+
+        assert result == {"isValid": False}
+
+    def test_invalid_uri_pattern(self, event_builder, lambda_context):
+        """read1FileUri not starting with s3:// should fail."""
+        event = event_builder({
+            "payloadVersion": "2025.06.04",
+            "data": {
+                "sampleId": "SMP001",
+                "libraryId": "L2401001",
+                "fastqListRows": [
+                    {"rgid": "RG1", "rgsm": "SMP001", "lane": 1, "read1FileUri": "https://b/r1.fq"}
+                ],
+            },
+        })
+
+        result = handler(event, lambda_context())
+
+        assert result == {"isValid": False}
+
+
+@pytest.mark.lambda_unit
+class TestValidateCommentOnError:
+    """Test that validation failures post comments when requested."""
+
+    def test_comment_posted_when_flag_true(self, mock_add_comment, event_builder, lambda_context):
+        """When addCommentOnError=True and validation fails, a comment is posted."""
+        event = event_builder({
+            "payloadVersion": "2025.06.04",
+            "workflowRunId": "wfr.abc123",
+            "addCommentOnError": True,
+            "data": {
+                "libraryId": "L2401001",
+                "fastqListRows": [
+                    {"rgid": "RG1", "rgsm": "SMP001", "lane": 1, "read1FileUri": "s3://b/r1.fq"}
+                ],
+            },
+        })
+
+        result = handler(event, lambda_context())
+
+        assert result == {"isValid": False}
+        mock_add_comment.assert_called_once()
+        call_kwargs = mock_add_comment.call_args[1]
+        assert "wfr.abc123" in str(call_kwargs)
+
+    def test_no_comment_when_flag_false(self, mock_add_comment, event_builder, lambda_context):
+        """When addCommentOnError is not set, no comment is posted."""
+        event = event_builder({
+            "payloadVersion": "2025.06.04",
+            "data": {
+                "libraryId": "L2401001",
+                "fastqListRows": [
+                    {"rgid": "RG1", "rgsm": "SMP001", "lane": 1, "read1FileUri": "s3://b/r1.fq"}
+                ],
+            },
+        })
+
+        result = handler(event, lambda_context())
+
+        assert result == {"isValid": False}
+        mock_add_comment.assert_not_called()
+
+    def test_no_comment_on_valid_payload(self, mock_add_comment, event_builder, lambda_context):
+        """Even with addCommentOnError=True, no comment on valid payload."""
+        event = event_builder({
+            "payloadVersion": "2025.06.04",
+            "workflowRunId": "wfr.abc123",
+            "addCommentOnError": True,
+            "data": {
+                "sampleId": "SMP001",
+                "libraryId": "L2401001",
+                "fastqListRows": [
+                    {"rgid": "RG1", "rgsm": "SMP001", "lane": 1, "read1FileUri": "s3://b/r1.fq"}
+                ],
+            },
+        })
+
+        result = handler(event, lambda_context())
+
+        assert result == {"isValid": True}
+        mock_add_comment.assert_not_called()

--- a/app/step-functions-templates/tests/conftest.py
+++ b/app/step-functions-templates/tests/conftest.py
@@ -1,0 +1,103 @@
+"""Step Functions test fixtures for service-dragen-wgts-dna-pipeline-manager.
+
+Provides fixtures for loading ASL templates, scenarios, mock configurations,
+and TestState API client access.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from orcabus_pipeline_test_utils.asl_validation.placeholder_resolver import (
+    resolve_placeholders,
+)
+from orcabus_pipeline_test_utils.sfn_teststate import (
+    TestStateClient,
+    TestStateAssertion,
+    PathAssertion,
+)
+
+
+# Directory paths
+TEMPLATES_DIR = Path(__file__).parent.parent
+TESTS_DIR = Path(__file__).parent
+MOCKS_DIR = TESTS_DIR / "mocks"
+SCENARIOS_DIR = TESTS_DIR / "scenarios"
+
+# SFN template names (without .asl.json suffix)
+SFN_TEMPLATES = [
+    "populate_draft_data_sfn_template",
+    "validate_draft_data_and_put_ready_event_sfn_template",
+    "ready_event_to_icav2_wes_request_event_sfn_template",
+    "icav2_wes_event_to_wrsc_event_sfn_template",
+]
+
+
+@pytest.fixture
+def load_template():
+    """Factory fixture to load and return an ASL template as a dict.
+
+    Automatically resolves ${__placeholder__} references with dummy ARNs.
+    """
+
+    def _load(template_name: str) -> dict:
+        template_path = TEMPLATES_DIR / f"{template_name}.asl.json"
+        raw_content = template_path.read_text()
+        resolved_content = resolve_placeholders(raw_content)
+        return json.loads(resolved_content)
+
+    return _load
+
+
+@pytest.fixture
+def load_scenario():
+    """Factory fixture to load a scenario JSON file.
+
+    Usage:
+        scenario = load_scenario("populate_draft_data_sfn_template", "happy_path")
+    """
+
+    def _load(template_name: str, scenario_name: str) -> dict:
+        scenario_path = SCENARIOS_DIR / template_name / f"{scenario_name}.json"
+        return json.loads(scenario_path.read_text())
+
+    return _load
+
+
+@pytest.fixture
+def load_mock_config():
+    """Factory fixture to load a MockConfigFile.json for a given template.
+
+    Usage:
+        mock_config = load_mock_config("populate_draft_data_sfn_template")
+    """
+
+    def _load(template_name: str) -> dict:
+        mock_config_path = MOCKS_DIR / template_name / "MockConfigFile.json"
+        return json.loads(mock_config_path.read_text())
+
+    return _load
+
+
+@pytest.fixture
+def teststate_client():
+    """Provide a TestState API client for state-level testing.
+
+    Returns a TestStateClient configured for the ap-southeast-2 region.
+    Requires AWS credentials with states:TestState permission.
+
+    Note: This fixture creates a fresh boto3 session that reads credentials
+    from the environment/config files directly, bypassing the moto-based
+    mock credentials set by the plugin's _aws_credentials fixture.
+    When a mock parameter is provided to test_state(), no roleArn is required.
+    """
+    import os
+    import boto3
+
+    # Create a session that bypasses the moto dummy credentials
+    # by reading from the default credential chain (env vars, config files, instance profile)
+    session = boto3.Session(region_name="ap-southeast-2")
+    return TestStateClient(region_name="ap-southeast-2", session=session)

--- a/app/step-functions-templates/tests/lambda_config.json
+++ b/app/step-functions-templates/tests/lambda_config.json
@@ -1,0 +1,88 @@
+{
+  "lambdas": {
+    "add_populate_draft_comment": {
+      "placeholder": "${__add_populate_draft_comment_lambda_function_arn__}",
+      "entry": "app/lambdas/add_populate_draft_comment_py"
+    },
+    "add_post_analysis_tags": {
+      "placeholder": "${__add_post_analysis_tags_lambda_function_arn__}",
+      "entry": "app/lambdas/add_post_analysis_tags_py"
+    },
+    "add_ready_comment": {
+      "placeholder": "${__add_ready_comment_lambda_function_arn__}",
+      "entry": "app/lambdas/add_ready_comment_py"
+    },
+    "add_wes_failure_comment": {
+      "placeholder": "${__add_wes_failure_comment_lambda_function_arn__}",
+      "entry": "app/lambdas/add_wes_failure_comment_py"
+    },
+    "calculate_downsampling_ratios": {
+      "placeholder": "${__calculate_downsampling_ratios_lambda_function_arn__}",
+      "entry": "app/lambdas/calculate_downsampling_ratios_py"
+    },
+    "check_ntsm_external": {
+      "placeholder": "${__check_ntsm_external_lambda_function_arn__}",
+      "entry": "app/lambdas/check_ntsm_external_py"
+    },
+    "check_ntsm_internal": {
+      "placeholder": "${__check_ntsm_internal_lambda_function_arn__}",
+      "entry": "app/lambdas/check_ntsm_internal_py"
+    },
+    "compare_payload": {
+      "placeholder": "${__compare_payload_lambda_function_arn__}",
+      "entry": "app/lambdas/compare_payload_py"
+    },
+    "convert_icav2_wes_state_change_event_to_wrsc_event": {
+      "placeholder": "${__convert_icav2_wes_state_change_event_to_wrsc_event_lambda_function_arn__}",
+      "entry": "app/lambdas/convert_icav2_wes_state_change_event_to_wrsc_event_py"
+    },
+    "dragen_wgts_dna_ready_to_icav2_wes_request": {
+      "placeholder": "${__dragen_wgts_dna_ready_to_icav2_wes_request_lambda_function_arn__}",
+      "entry": "app/lambdas/dragen_wgts_dna_ready_to_icav2_wes_request_py"
+    },
+    "generate_wru_event_object_with_merged_data": {
+      "placeholder": "${__generate_wru_event_object_with_merged_data_lambda_function_arn__}",
+      "entry": "app/lambdas/generate_wru_event_object_with_merged_data_py"
+    },
+    "get_fastq_id_list_from_rgid_list": {
+      "placeholder": "${__get_fastq_id_list_from_rgid_list_lambda_function_arn__}",
+      "entry": "app/lambdas/get_fastq_id_list_from_rgid_list_py"
+    },
+    "get_fastq_list_rows_from_rgid_list": {
+      "placeholder": "${__get_fastq_list_rows_from_rgid_list_lambda_function_arn__}",
+      "entry": "app/lambdas/get_fastq_list_rows_from_rgid_list_py"
+    },
+    "get_fastq_rgids_from_library_id": {
+      "placeholder": "${__get_fastq_rgids_from_library_id_lambda_function_arn__}",
+      "entry": "app/lambdas/get_fastq_rgids_from_library_id_py"
+    },
+    "get_libraries": {
+      "placeholder": "${__get_libraries_lambda_function_arn__}",
+      "entry": "app/lambdas/get_libraries_py"
+    },
+    "get_metadata_tags": {
+      "placeholder": "${__get_metadata_tags_lambda_function_arn__}",
+      "entry": "app/lambdas/get_metadata_tags_py"
+    },
+    "get_missing_schema_fields": {
+      "placeholder": "${__get_missing_schema_fields_lambda_function_arn__}",
+      "entry": "app/lambdas/get_missing_schema_fields_py"
+    },
+    "get_project_base_uri_from_project_id": {
+      "placeholder": "${__get_project_base_uri_from_project_id_lambda_function_arn__}",
+      "entry": "app/lambdas/get_project_base_uri_from_project_id_py"
+    },
+    "get_qc_summary_stats_from_rgid_list": {
+      "placeholder": "${__get_qc_summary_stats_from_rgid_list_lambda_function_arn__}",
+      "entry": "app/lambdas/get_qc_summary_stats_from_rgid_list_py"
+    },
+    "post_schema_validation": {
+      "placeholder": "${__post_schema_validation_lambda_function_arn__}",
+      "entry": "app/lambdas/post_schema_validation_py"
+    },
+    "validate_draft_complete_schema": {
+      "placeholder": "${__validate_draft_complete_schema_lambda_function_arn__}",
+      "entry": "app/lambdas/validate_draft_complete_schema_py"
+    }
+  }
+}

--- a/app/step-functions-templates/tests/mocks/icav2_wes_event_to_wrsc_event_sfn_template/MockConfigFile.json
+++ b/app/step-functions-templates/tests/mocks/icav2_wes_event_to_wrsc_event_sfn_template/MockConfigFile.json
@@ -1,0 +1,104 @@
+{
+  "StateMachines": {
+    "Icav2WesEventToWrscEventSfn": {
+      "TestCases": {
+        "HappyPath": {
+          "Convert ICAv2 WES event to WRSC Event": "ConvertIcav2WesToWrscSucceeded",
+          "Add post analysis tags (germline)": "AddPostAnalysisTagsGermline",
+          "Push WRSC Event": "PushWrscEvent"
+        },
+        "ErrorPath": {
+          "Convert ICAv2 WES event to WRSC Event": "ConvertIcav2WesToWrscFailed",
+          "Add comment for WES failure": "AddWesFailureComment",
+          "Push WRSC Event": "PushWrscEvent"
+        }
+      }
+    }
+  },
+  "MockedResponses": {
+    "ConvertIcav2WesToWrscSucceeded": {
+      "0": {
+        "Return": {
+          "Payload": {
+            "workflowRunStateChangeEvent": {
+              "orcabusId": "wfr.12345",
+              "portalRunId": "portal-run-001",
+              "status": "SUCCEEDED",
+              "timestamp": "2024-01-01T00:00:00Z",
+              "payload": {
+                "version": "1.0",
+                "data": {
+                  "inputs": {},
+                  "engineParameters": {
+                    "outputUri": "icav2://proj-12345/output/portal-run-001/"
+                  },
+                  "outputs": {
+                    "dragenGermlineVariantCallingOutputRelPath": "germline/",
+                    "dragenSomaticVariantCallingOutputRelPath": "somatic/"
+                  },
+                  "tags": {
+                    "libraryId": "L001",
+                    "tumorLibraryId": "L002",
+                    "subjectId": "SBJ001"
+                  }
+                }
+              }
+            },
+            "errorMessageUri": null,
+            "errorType": null
+          }
+        }
+      }
+    },
+    "ConvertIcav2WesToWrscFailed": {
+      "0": {
+        "Return": {
+          "Payload": {
+            "workflowRunStateChangeEvent": {
+              "orcabusId": "wfr.12345",
+              "portalRunId": "portal-run-001",
+              "status": "FAILED",
+              "timestamp": "2024-01-01T01:00:00Z",
+              "payload": {
+                "version": "1.0",
+                "data": {}
+              }
+            },
+            "errorMessageUri": "s3://logs/error.log",
+            "errorType": "InternalError"
+          }
+        }
+      }
+    },
+    "AddPostAnalysisTagsGermline": {
+      "0": {
+        "Return": {
+          "Payload": {
+            "tags": {
+              "germlineVcfUri": "s3://output/germline/variants.vcf.gz"
+            }
+          }
+        }
+      }
+    },
+    "AddWesFailureComment": {
+      "0": {
+        "Return": {
+          "Payload": {}
+        }
+      }
+    },
+    "PushWrscEvent": {
+      "0": {
+        "Return": {
+          "Entries": [
+            {
+              "EventId": "evt-wrsc-001"
+            }
+          ],
+          "FailedEntryCount": 0
+        }
+      }
+    }
+  }
+}

--- a/app/step-functions-templates/tests/mocks/populate_draft_data_sfn_template/MockConfigFile.json
+++ b/app/step-functions-templates/tests/mocks/populate_draft_data_sfn_template/MockConfigFile.json
@@ -1,0 +1,186 @@
+{
+  "StateMachines": {
+    "PopulateDraftDataSfn": {
+      "TestCases": {
+        "HappyPath": {
+          "Validate draft data": "ValidateDraftDataInvalid",
+          "Get Default Project Id": "GetDefaultProjectId",
+          "Get default pipeline id": "GetDefaultPipelineId",
+          "Get default output uri prefix": "GetDefaultOutputUriPrefix",
+          "Get default logs uri prefix": "GetDefaultLogsUriPrefix",
+          "Get primitive tags from linked libraries": "GetLibraries",
+          "Get fastq list rgids from normal libraries": "GetFastqRgidsFromLibraryId",
+          "Get metadata tags": "GetMetadataTags",
+          "Add change comment": "AddPopulateDraftComment",
+          "Get fastq ids from rgid list": "GetFastqIdListFromRgidList",
+          "Wait for fastq": "WaitForFastq",
+          "Get prefix from project id": "GetPrefixFromProjectId",
+          "Get fastq list rows from rgid list": "GetFastqListRowsFromRgidList"
+        },
+        "ErrorPath": {
+          "Validate draft data": "ValidateDraftDataInvalid",
+          "Get Default Project Id": "GetDefaultProjectIdError"
+        }
+      }
+    }
+  },
+  "MockedResponses": {
+    "ValidateDraftDataValid": {
+      "0": {
+        "Return": {
+          "Payload": {
+            "isValid": true
+          }
+        }
+      }
+    },
+    "ValidateDraftDataInvalid": {
+      "0": {
+        "Return": {
+          "Payload": {
+            "isValid": false
+          }
+        }
+      }
+    },
+    "GetDefaultProjectId": {
+      "0": {
+        "Return": {
+          "Parameter": {
+            "Value": "proj-12345"
+          }
+        }
+      }
+    },
+    "GetDefaultProjectIdError": {
+      "0": {
+        "Throw": {
+          "Error": "Ssm.ParameterNotFoundException",
+          "Cause": "Parameter /orcabus/workflows/dragen-wgts-dna/default-project-id not found"
+        }
+      }
+    },
+    "GetDefaultPipelineId": {
+      "0": {
+        "Return": {
+          "Parameter": {
+            "Value": "pipeline-abcdef-1234"
+          }
+        }
+      }
+    },
+    "GetDefaultOutputUriPrefix": {
+      "0": {
+        "Return": {
+          "Parameter": {
+            "Value": "icav2://project-id/output/"
+          }
+        }
+      }
+    },
+    "GetDefaultLogsUriPrefix": {
+      "0": {
+        "Return": {
+          "Parameter": {
+            "Value": "icav2://project-id/logs/"
+          }
+        }
+      }
+    },
+    "GetLibraries": {
+      "0": {
+        "Return": {
+          "Payload": {
+            "libraryId": "L001",
+            "tumorLibraryId": "L002",
+            "subjectId": "SBJ001",
+            "individualId": "IND001"
+          }
+        }
+      }
+    },
+    "GetFastqRgidsFromLibraryId": {
+      "0": {
+        "Return": {
+          "Payload": {
+            "fastqRgidList": ["RGID001.L001.LANE1"]
+          }
+        }
+      }
+    },
+    "GetMetadataTags": {
+      "0": {
+        "Return": {
+          "Payload": {
+            "libraryObj": {
+              "subject": {
+                "subjectId": "SBJ001",
+                "individualSet": [
+                  {
+                    "individualId": "IND001"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "AddPopulateDraftComment": {
+      "0": {
+        "Return": {
+          "Payload": {}
+        }
+      }
+    },
+    "GetFastqIdListFromRgidList": {
+      "0": {
+        "Return": {
+          "Payload": {
+            "fastqIdList": ["fq.ABCDEF12345"]
+          }
+        }
+      }
+    },
+    "WaitForFastq": {
+      "0": {
+        "Return": {
+          "fastqListRows": [
+            {
+              "rgid": "RGID001.L001.LANE1",
+              "read1FileUri": "s3://bucket/read1.fastq.gz",
+              "read2FileUri": "s3://bucket/read2.fastq.gz"
+            }
+          ]
+        }
+      }
+    },
+    "GetPrefixFromProjectId": {
+      "0": {
+        "Return": {
+          "Payload": {
+            "s3Uri": "s3://pipeline-cache/dragen-wgts-dna/"
+          }
+        }
+      }
+    },
+    "GetFastqListRowsFromRgidList": {
+      "0": {
+        "Return": {
+          "Payload": {
+            "fastqListRows": [
+              {
+                "rgid": "RGID001.L001.LANE1",
+                "rgsm": "SMP001",
+                "rglb": "L001",
+                "lane": 1,
+                "read1FileUri": "s3://pipeline-cache/dragen-wgts-dna/read1.fastq.gz",
+                "read2FileUri": "s3://pipeline-cache/dragen-wgts-dna/read2.fastq.gz"
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/step-functions-templates/tests/mocks/ready_event_to_icav2_wes_request_event_sfn_template/MockConfigFile.json
+++ b/app/step-functions-templates/tests/mocks/ready_event_to_icav2_wes_request_event_sfn_template/MockConfigFile.json
@@ -1,0 +1,65 @@
+{
+  "StateMachines": {
+    "ReadyEventToIcav2WesRequestEventSfn": {
+      "TestCases": {
+        "HappyPath": {
+          "Add Ready Comment": "AddReadyComment",
+          "Convert Dragen WGTS DNA Ready Event to ICAv2 WES Event": "ConvertReadyToIcav2Wes",
+          "Push WES Event": "PushWesEvent"
+        },
+        "ErrorPath": {
+          "Add Ready Comment": "AddReadyComment",
+          "Convert Dragen WGTS DNA Ready Event to ICAv2 WES Event": "ConvertReadyToIcav2WesError"
+        }
+      }
+    }
+  },
+  "MockedResponses": {
+    "AddReadyComment": {
+      "0": {
+        "Return": {
+          "Payload": {}
+        }
+      }
+    },
+    "ConvertReadyToIcav2Wes": {
+      "0": {
+        "Return": {
+          "Payload": {
+            "icav2WesRequestEventDetail": {
+              "workflowRunId": "wfr.12345",
+              "portalRunId": "portal-run-001",
+              "pipelineId": "pipeline-abcdef-1234",
+              "projectId": "proj-12345",
+              "inputJson": "{\"fastq_list_rows\": []}",
+              "engineParameters": {
+                "outputUri": "icav2://proj-12345/output/portal-run-001/",
+                "logsUri": "icav2://proj-12345/logs/portal-run-001/"
+              }
+            }
+          }
+        }
+      }
+    },
+    "ConvertReadyToIcav2WesError": {
+      "0": {
+        "Throw": {
+          "Error": "ValueError",
+          "Cause": "Missing required field 'pipelineId' in ready event payload"
+        }
+      }
+    },
+    "PushWesEvent": {
+      "0": {
+        "Return": {
+          "Entries": [
+            {
+              "EventId": "evt-67890"
+            }
+          ],
+          "FailedEntryCount": 0
+        }
+      }
+    }
+  }
+}

--- a/app/step-functions-templates/tests/mocks/validate_draft_data_and_put_ready_event_sfn_template/MockConfigFile.json
+++ b/app/step-functions-templates/tests/mocks/validate_draft_data_and_put_ready_event_sfn_template/MockConfigFile.json
@@ -1,0 +1,57 @@
+{
+  "StateMachines": {
+    "ValidateDraftDataAndPutReadyEventSfn": {
+      "TestCases": {
+        "HappyPath": {
+          "Validate Draft Complete Event": "ValidateDraftCompleteValid",
+          "Run post-schema validation": "PostSchemaValidationValid",
+          "Push READY Event": "PushReadyEvent"
+        },
+        "ErrorPath": {
+          "Validate Draft Complete Event": "ValidateDraftCompleteInvalid"
+        }
+      }
+    }
+  },
+  "MockedResponses": {
+    "ValidateDraftCompleteValid": {
+      "0": {
+        "Return": {
+          "Payload": {
+            "isValid": true
+          }
+        }
+      }
+    },
+    "ValidateDraftCompleteInvalid": {
+      "0": {
+        "Return": {
+          "Payload": {
+            "isValid": false
+          }
+        }
+      }
+    },
+    "PostSchemaValidationValid": {
+      "0": {
+        "Return": {
+          "Payload": {
+            "isValid": true
+          }
+        }
+      }
+    },
+    "PushReadyEvent": {
+      "0": {
+        "Return": {
+          "Entries": [
+            {
+              "EventId": "evt-12345"
+            }
+          ],
+          "FailedEntryCount": 0
+        }
+      }
+    }
+  }
+}

--- a/app/step-functions-templates/tests/scenarios/icav2_wes_event_to_wrsc_event_sfn_template/error_path.json
+++ b/app/step-functions-templates/tests/scenarios/icav2_wes_event_to_wrsc_event_sfn_template/error_path.json
@@ -1,0 +1,21 @@
+{
+  "scenario_name": "error_path",
+  "description": "An ICAv2 WES FAILED event is converted to a WRSC event, a failure comment is added, and the event is pushed to EventBridge with FAILED status",
+  "state_machine_template": "icav2_wes_event_to_wrsc_event_sfn_template.asl.json",
+  "test_case_name": "ErrorPath",
+  "input": {
+    "analysisId": "analysis-12345",
+    "status": "FAILED",
+    "portalRunId": "portal-run-001",
+    "workflowRunId": "wfr.ABCDEF123456",
+    "errorMessage": "Pipeline execution failed: out of memory"
+  },
+  "expected_status": "SUCCEEDED",
+  "expected_output": null,
+  "expected_states_visited": [
+    "Convert ICAv2 WES event to WRSC Event",
+    "Workflow status decision tree",
+    "Add comment for WES failure",
+    "Push WRSC Event"
+  ]
+}

--- a/app/step-functions-templates/tests/scenarios/icav2_wes_event_to_wrsc_event_sfn_template/happy_path.json
+++ b/app/step-functions-templates/tests/scenarios/icav2_wes_event_to_wrsc_event_sfn_template/happy_path.json
@@ -1,0 +1,21 @@
+{
+  "scenario_name": "happy_path",
+  "description": "An ICAv2 WES SUCCEEDED event is converted to a WRSC event, post-analysis tags are added, and the event is pushed to EventBridge",
+  "state_machine_template": "icav2_wes_event_to_wrsc_event_sfn_template.asl.json",
+  "test_case_name": "HappyPath",
+  "input": {
+    "analysisId": "analysis-12345",
+    "status": "SUCCEEDED",
+    "portalRunId": "portal-run-001",
+    "workflowRunId": "wfr.ABCDEF123456",
+    "outputUri": "icav2://proj-12345/output/portal-run-001/"
+  },
+  "expected_status": "SUCCEEDED",
+  "expected_output": null,
+  "expected_states_visited": [
+    "Convert ICAv2 WES event to WRSC Event",
+    "Workflow status decision tree",
+    "Add post analysis tags",
+    "Push WRSC Event"
+  ]
+}

--- a/app/step-functions-templates/tests/scenarios/populate_draft_data_sfn_template/error_path.json
+++ b/app/step-functions-templates/tests/scenarios/populate_draft_data_sfn_template/error_path.json
@@ -1,0 +1,33 @@
+{
+  "scenario_name": "error_path",
+  "description": "SSM parameter lookup for project ID fails, causing the state machine to fail with a ParameterNotFoundException",
+  "state_machine_template": "populate_draft_data_sfn_template.asl.json",
+  "test_case_name": "ErrorPath",
+  "input": {
+    "orcabusId": "wfr.ABCDEF123456",
+    "portalRunId": "portal-run-002",
+    "workflow": {
+      "workflowName": "dragen-wgts-dna",
+      "version": "4.3.6",
+      "executionEnginePipelineId": null
+    },
+    "libraries": [
+      {
+        "libraryId": "L001",
+        "readsets": null
+      }
+    ],
+    "payload": {
+      "version": "1.0",
+      "data": {}
+    }
+  },
+  "expected_status": "FAILED",
+  "expected_output": null,
+  "expected_states_visited": [
+    "Get draft payload var",
+    "Validate draft data",
+    "Draft data is valid",
+    "Get Engine parameters"
+  ]
+}

--- a/app/step-functions-templates/tests/scenarios/populate_draft_data_sfn_template/happy_path.json
+++ b/app/step-functions-templates/tests/scenarios/populate_draft_data_sfn_template/happy_path.json
@@ -1,0 +1,40 @@
+{
+  "scenario_name": "happy_path",
+  "description": "Draft data is incomplete (isValid=false), so the state machine populates engine parameters, tags, and input data from SSM and Lambda lookups, then emits a DRAFT update event",
+  "state_machine_template": "populate_draft_data_sfn_template.asl.json",
+  "test_case_name": "HappyPath",
+  "input": {
+    "orcabusId": "wfr.ABCDEF123456",
+    "portalRunId": "portal-run-001",
+    "workflow": {
+      "workflowName": "dragen-wgts-dna",
+      "version": "4.3.6",
+      "executionEnginePipelineId": null
+    },
+    "libraries": [
+      {
+        "libraryId": "L001",
+        "readsets": null
+      },
+      {
+        "libraryId": "L002",
+        "readsets": null
+      }
+    ],
+    "payload": {
+      "version": "1.0",
+      "data": {}
+    }
+  },
+  "expected_status": "SUCCEEDED",
+  "expected_output": null,
+  "expected_states_visited": [
+    "Get draft payload var",
+    "Validate draft data",
+    "Draft data is valid",
+    "Get Engine parameters",
+    "Do we have matching libraries",
+    "Get primitive tags from linked libraries",
+    "Get tags"
+  ]
+}

--- a/app/step-functions-templates/tests/scenarios/ready_event_to_icav2_wes_request_event_sfn_template/error_path.json
+++ b/app/step-functions-templates/tests/scenarios/ready_event_to_icav2_wes_request_event_sfn_template/error_path.json
@@ -1,0 +1,30 @@
+{
+  "scenario_name": "error_path",
+  "description": "The conversion Lambda raises a ValueError due to missing pipelineId, causing the state machine to fail",
+  "state_machine_template": "ready_event_to_icav2_wes_request_event_sfn_template.asl.json",
+  "test_case_name": "ErrorPath",
+  "input": {
+    "orcabusId": "wfr.ABCDEF123456",
+    "portalRunId": "portal-run-002",
+    "status": "READY",
+    "workflow": {
+      "workflowName": "dragen-wgts-dna",
+      "version": "4.3.6"
+    },
+    "payload": {
+      "version": "1.0",
+      "data": {
+        "inputs": {},
+        "engineParameters": {},
+        "tags": {}
+      }
+    }
+  },
+  "expected_status": "FAILED",
+  "expected_output": null,
+  "expected_states_visited": [
+    "Save inputs",
+    "Add Ready Comment",
+    "Convert Dragen WGTS DNA Ready Event to ICAv2 WES Event"
+  ]
+}

--- a/app/step-functions-templates/tests/scenarios/ready_event_to_icav2_wes_request_event_sfn_template/happy_path.json
+++ b/app/step-functions-templates/tests/scenarios/ready_event_to_icav2_wes_request_event_sfn_template/happy_path.json
@@ -1,0 +1,51 @@
+{
+  "scenario_name": "happy_path",
+  "description": "A READY event is successfully converted to an ICAv2 WES request event and pushed to EventBridge",
+  "state_machine_template": "ready_event_to_icav2_wes_request_event_sfn_template.asl.json",
+  "test_case_name": "HappyPath",
+  "input": {
+    "orcabusId": "wfr.ABCDEF123456",
+    "portalRunId": "portal-run-001",
+    "status": "READY",
+    "workflow": {
+      "workflowName": "dragen-wgts-dna",
+      "version": "4.3.6"
+    },
+    "payload": {
+      "version": "1.0",
+      "data": {
+        "inputs": {
+          "fastqListRows": [
+            {
+              "rgid": "RGID001.L001.LANE1",
+              "rgsm": "SMP001",
+              "rglb": "L001",
+              "lane": 1,
+              "read1FileUri": "s3://bucket/read1.fastq.gz",
+              "read2FileUri": "s3://bucket/read2.fastq.gz"
+            }
+          ]
+        },
+        "engineParameters": {
+          "projectId": "proj-12345",
+          "pipelineId": "pipeline-abcdef-1234",
+          "outputUri": "icav2://proj-12345/output/portal-run-001/",
+          "logsUri": "icav2://proj-12345/logs/portal-run-001/"
+        },
+        "tags": {
+          "libraryId": "L001",
+          "subjectId": "SBJ001",
+          "individualId": "IND001"
+        }
+      }
+    }
+  },
+  "expected_status": "SUCCEEDED",
+  "expected_output": null,
+  "expected_states_visited": [
+    "Save inputs",
+    "Add Ready Comment",
+    "Convert Dragen WGTS DNA Ready Event to ICAv2 WES Event",
+    "Push WES Event"
+  ]
+}

--- a/app/step-functions-templates/tests/scenarios/validate_draft_data_and_put_ready_event_sfn_template/error_path.json
+++ b/app/step-functions-templates/tests/scenarios/validate_draft_data_and_put_ready_event_sfn_template/error_path.json
@@ -1,0 +1,31 @@
+{
+  "scenario_name": "error_path",
+  "description": "Draft data fails schema validation (isValid=false), so the state machine exits via the Pass state without emitting a READY event",
+  "state_machine_template": "validate_draft_data_and_put_ready_event_sfn_template.asl.json",
+  "test_case_name": "ErrorPath",
+  "input": {
+    "orcabusId": "wfr.ABCDEF123456",
+    "portalRunId": "portal-run-002",
+    "workflow": {
+      "workflowName": "dragen-wgts-dna",
+      "version": "4.3.6"
+    },
+    "libraries": [
+      {
+        "libraryId": "L001"
+      }
+    ],
+    "payload": {
+      "version": "1.0",
+      "data": {}
+    }
+  },
+  "expected_status": "SUCCEEDED",
+  "expected_output": null,
+  "expected_states_visited": [
+    "Save Event Vars",
+    "Validate Draft Complete Event",
+    "Is Draft Event Complete?",
+    "Pass"
+  ]
+}

--- a/app/step-functions-templates/tests/scenarios/validate_draft_data_and_put_ready_event_sfn_template/happy_path.json
+++ b/app/step-functions-templates/tests/scenarios/validate_draft_data_and_put_ready_event_sfn_template/happy_path.json
@@ -1,0 +1,57 @@
+{
+  "scenario_name": "happy_path",
+  "description": "Draft data passes schema validation and post-schema validation, resulting in a READY event being pushed to EventBridge",
+  "state_machine_template": "validate_draft_data_and_put_ready_event_sfn_template.asl.json",
+  "test_case_name": "HappyPath",
+  "input": {
+    "orcabusId": "wfr.ABCDEF123456",
+    "portalRunId": "portal-run-001",
+    "workflow": {
+      "workflowName": "dragen-wgts-dna",
+      "version": "4.3.6"
+    },
+    "libraries": [
+      {
+        "libraryId": "L001"
+      }
+    ],
+    "payload": {
+      "version": "1.0",
+      "data": {
+        "inputs": {
+          "fastqListRows": [
+            {
+              "rgid": "RGID001.L001.LANE1",
+              "rgsm": "SMP001",
+              "rglb": "L001",
+              "lane": 1,
+              "read1FileUri": "s3://bucket/read1.fastq.gz",
+              "read2FileUri": "s3://bucket/read2.fastq.gz"
+            }
+          ]
+        },
+        "engineParameters": {
+          "projectId": "proj-12345",
+          "pipelineId": "pipeline-abcdef-1234",
+          "outputUri": "icav2://proj-12345/output/portal-run-001/",
+          "logsUri": "icav2://proj-12345/logs/portal-run-001/"
+        },
+        "tags": {
+          "libraryId": "L001",
+          "subjectId": "SBJ001",
+          "individualId": "IND001"
+        }
+      }
+    }
+  },
+  "expected_status": "SUCCEEDED",
+  "expected_output": null,
+  "expected_states_visited": [
+    "Save Event Vars",
+    "Validate Draft Complete Event",
+    "Is Draft Event Complete?",
+    "Run post-schema validation",
+    "Workflow Inputs are Valid",
+    "Push READY Event"
+  ]
+}

--- a/app/step-functions-templates/tests/test_asl_validation.py
+++ b/app/step-functions-templates/tests/test_asl_validation.py
@@ -1,0 +1,195 @@
+"""ASL validation tests for service-dragen-wgts-dna-pipeline-manager.
+
+Loads each ASL template from app/step-functions-templates/, resolves
+placeholders, and validates structural correctness, state references,
+and Lambda ARN cross-references against the CDK lambda configuration.
+
+Requirements: 4.1, 4.3, 4.4
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from orcabus_pipeline_test_utils.asl_validation import (
+    ValidationCategory,
+    check_lambda_arn_references,
+    check_state_references,
+    resolve_placeholders,
+    validate_asl_definition,
+)
+
+
+# Paths relative to this test file
+TESTS_DIR = Path(__file__).parent
+TEMPLATES_DIR = TESTS_DIR.parent
+APP_DIR = TEMPLATES_DIR.parent
+SERVICE_ROOT = APP_DIR.parent
+LAMBDA_CONFIG_PATH = TESTS_DIR / "lambda_config.json"
+
+# Discover all .asl.json files in the templates directory
+ASL_TEMPLATE_FILES = sorted(TEMPLATES_DIR.glob("*.asl.json"))
+
+
+@pytest.fixture(scope="module")
+def cdk_lambda_config() -> dict:
+    """Load the CDK lambda configuration map."""
+    assert LAMBDA_CONFIG_PATH.exists(), (
+        f"lambda_config.json not found at {LAMBDA_CONFIG_PATH}. "
+        "Create it to map Lambda ARN placeholders to CDK-defined functions."
+    )
+    return json.loads(LAMBDA_CONFIG_PATH.read_text())
+
+
+@pytest.fixture(scope="module")
+def resolved_templates() -> dict[str, dict]:
+    """Load and resolve placeholders for all ASL templates.
+
+    Returns a dict mapping template file name to parsed ASL JSON.
+    """
+    templates: dict[str, dict] = {}
+    for template_path in ASL_TEMPLATE_FILES:
+        raw_content = template_path.read_text()
+        resolved_content = resolve_placeholders(raw_content)
+        templates[template_path.name] = json.loads(resolved_content)
+    return templates
+
+
+class TestAslTemplateDiscovery:
+    """Test that ASL templates are discoverable."""
+
+    def test_at_least_one_template_exists(self):
+        """Verify the templates directory contains at least one .asl.json file."""
+        assert len(ASL_TEMPLATE_FILES) > 0, (
+            f"No .asl.json files found in {TEMPLATES_DIR}"
+        )
+
+    def test_all_templates_are_valid_json(self):
+        """Verify all ASL template files are parseable JSON."""
+        for template_path in ASL_TEMPLATE_FILES:
+            raw_content = template_path.read_text()
+            try:
+                json.loads(raw_content)
+            except json.JSONDecodeError as e:
+                pytest.fail(
+                    f"Template {template_path.name} is not valid JSON: {e}"
+                )
+
+
+class TestAslStructuralValidation:
+    """Test structural validation of each ASL template."""
+
+    @pytest.mark.parametrize(
+        "template_path",
+        ASL_TEMPLATE_FILES,
+        ids=[p.name for p in ASL_TEMPLATE_FILES],
+    )
+    def test_template_passes_structural_validation(
+        self, template_path: Path
+    ):
+        """Each ASL template should pass structural validation after placeholder resolution."""
+        raw_content = template_path.read_text()
+        resolved_content = resolve_placeholders(raw_content)
+        asl_json = json.loads(resolved_content)
+
+        result = validate_asl_definition(asl_json, file_path=str(template_path))
+
+        assert result.category == ValidationCategory.SUCCESS, (
+            f"Template {template_path.name} failed validation with "
+            f"category={result.category.value}:\n"
+            + "\n".join(f"  - {e}" for e in result.errors)
+        )
+
+
+class TestStateReferences:
+    """Test that all state references in ASL templates are valid."""
+
+    @pytest.mark.parametrize(
+        "template_path",
+        ASL_TEMPLATE_FILES,
+        ids=[p.name for p in ASL_TEMPLATE_FILES],
+    )
+    def test_template_has_valid_state_references(
+        self, template_path: Path
+    ):
+        """All Next, Default, and Choice branch targets should reference existing states."""
+        raw_content = template_path.read_text()
+        resolved_content = resolve_placeholders(raw_content)
+        asl_json = json.loads(resolved_content)
+
+        errors = check_state_references(asl_json)
+
+        assert errors == [], (
+            f"Template {template_path.name} has dangling state references:\n"
+            + "\n".join(f"  - {e}" for e in errors)
+        )
+
+
+class TestLambdaArnReferences:
+    """Test that all Lambda ARN placeholders are defined in the CDK lambda config."""
+
+    @pytest.mark.parametrize(
+        "template_path",
+        ASL_TEMPLATE_FILES,
+        ids=[p.name for p in ASL_TEMPLATE_FILES],
+    )
+    def test_template_lambda_arns_are_in_config(
+        self, template_path: Path, cdk_lambda_config: dict
+    ):
+        """Every Lambda ARN placeholder in the template should have a CDK config entry."""
+        raw_content = template_path.read_text()
+        # Parse the raw (unresolved) content to find placeholders
+        asl_json = json.loads(resolve_placeholders(raw_content))
+
+        # We need to check against the raw content for Lambda ARN placeholders,
+        # so re-parse without resolution for the cross-reference check
+        raw_asl_json = json.loads(raw_content)
+
+        errors = check_lambda_arn_references(raw_asl_json, cdk_lambda_config)
+
+        assert errors == [], (
+            f"Template {template_path.name} has unresolved Lambda ARN placeholders:\n"
+            + "\n".join(f"  - {e}" for e in errors)
+        )
+
+    def test_lambda_config_entries_have_valid_paths(
+        self, cdk_lambda_config: dict
+    ):
+        """Each entry in lambda_config.json should point to an existing Lambda directory."""
+        lambdas = cdk_lambda_config.get("lambdas", {})
+
+        for lambda_name, lambda_info in lambdas.items():
+            entry_path = SERVICE_ROOT / lambda_info["entry"]
+            assert entry_path.exists(), (
+                f"Lambda config entry '{lambda_name}' references "
+                f"non-existent path: {lambda_info['entry']}"
+            )
+
+    def test_lambda_config_covers_all_asl_placeholders(
+        self, cdk_lambda_config: dict
+    ):
+        """The lambda_config.json should cover all Lambda ARN placeholders across all templates."""
+        import re
+
+        pattern = re.compile(r"\$\{__([a-z0-9_]+_lambda_function_arn)__\}")
+
+        all_placeholders: set[str] = set()
+        for template_path in ASL_TEMPLATE_FILES:
+            raw_content = template_path.read_text()
+            found = pattern.findall(raw_content)
+            for inner_name in found:
+                all_placeholders.add(f"${{__{inner_name}__}}")
+
+        known_placeholders: set[str] = set()
+        for lambda_info in cdk_lambda_config.get("lambdas", {}).values():
+            if "placeholder" in lambda_info:
+                known_placeholders.add(lambda_info["placeholder"])
+
+        missing = all_placeholders - known_placeholders
+        assert missing == set(), (
+            f"Lambda ARN placeholders not covered in lambda_config.json:\n"
+            + "\n".join(f"  - {p}" for p in sorted(missing))
+        )

--- a/app/step-functions-templates/tests/test_populate_draft_data.py
+++ b/app/step-functions-templates/tests/test_populate_draft_data.py
@@ -1,0 +1,114 @@
+"""TestState API tests for populate_draft_data_sfn_template.
+
+Validates JSONata expressions, Choice branching, and Task state data flow
+for the draft data population state machine.
+"""
+
+from __future__ import annotations
+
+import json
+
+import boto3
+import pytest
+
+from orcabus_pipeline_test_utils.sfn_teststate import TestStateClient, TestStateAssertion
+
+TEMPLATE_NAME = "populate_draft_data_sfn_template"
+
+# Capture SFN client at import time before moto overwrites credentials.
+_SFN_CLIENT = boto3.client("stepfunctions", region_name="ap-southeast-2")
+
+
+@pytest.fixture(scope="module")
+def sfn_client():
+    """TestState client with real AWS credentials."""
+    return TestStateClient(region_name="ap-southeast-2", client=_SFN_CLIENT)
+
+
+@pytest.mark.sfn_teststate
+class TestGetDraftPayloadVar:
+    """Test the initial Pass state variable assignment."""
+
+    def test_assigns_variables_from_input(self, sfn_client, load_template, load_scenario):
+        """Pass state should assign detail, data, engineParameters, tags, etc."""
+        definition = load_template(TEMPLATE_NAME)
+        scenario = load_scenario(TEMPLATE_NAME, "happy_path")
+
+        result = sfn_client.test_state(
+            definition=definition,
+            input_data=scenario["input"],
+            state_name="Get draft payload var",
+            inspection_level="DEBUG",
+        )
+
+        assertion = TestStateAssertion(result)
+        assert assertion.assert_succeeded().passed
+
+
+@pytest.mark.sfn_teststate
+class TestValidateDraftData:
+    """Test the 'Validate draft data' Task state with mocked responses."""
+
+    def test_valid_schema_returns_is_valid_true(self, sfn_client, load_template):
+        """When Lambda returns isValid=true, output should reflect that."""
+        definition = load_template(TEMPLATE_NAME)
+
+        result = sfn_client.test_state(
+            definition=definition,
+            input_data={},
+            variables={"data": {"inputs": {}, "engineParameters": {}}},
+            state_name="Validate draft data",
+            mock_result={"Payload": {"isValid": True}, "StatusCode": 200},
+            field_validation_mode="NONE",
+        )
+
+        assertion = TestStateAssertion(result)
+        assert assertion.assert_succeeded().passed
+
+    def test_invalid_schema_returns_is_valid_false(self, sfn_client, load_template):
+        """When Lambda returns isValid=false, output should reflect that."""
+        definition = load_template(TEMPLATE_NAME)
+
+        result = sfn_client.test_state(
+            definition=definition,
+            input_data={},
+            variables={"data": {}},
+            state_name="Validate draft data",
+            mock_result={"Payload": {"isValid": False}, "StatusCode": 200},
+            field_validation_mode="NONE",
+        )
+
+        assertion = TestStateAssertion(result)
+        assert assertion.assert_succeeded().passed
+
+
+@pytest.mark.sfn_teststate
+class TestDraftDataIsValid:
+    """Test the 'Draft data is valid' Choice state branching."""
+
+    def test_valid_data_exits_early(self, sfn_client, load_template):
+        """When isValid=true, should exit without populating engine parameters."""
+        definition = load_template(TEMPLATE_NAME)
+
+        result = sfn_client.test_state(
+            definition=definition,
+            input_data={"isValid": True},
+            state_name="Draft data is valid",
+        )
+
+        assertion = TestStateAssertion(result)
+        assert assertion.assert_succeeded().passed
+
+    def test_invalid_data_continues_to_populate(self, sfn_client, load_template):
+        """When isValid=false, should route to 'Get Engine parameters'."""
+        definition = load_template(TEMPLATE_NAME)
+
+        result = sfn_client.test_state(
+            definition=definition,
+            input_data={"isValid": False},
+            state_name="Draft data is valid",
+        )
+
+        assertion = TestStateAssertion(result)
+        assert assertion.assert_succeeded().passed
+        assert assertion.assert_next_state("Get Engine parameters").passed

--- a/app/step-functions-templates/tests/test_ready_event_to_icav2_wes_request_event.py
+++ b/app/step-functions-templates/tests/test_ready_event_to_icav2_wes_request_event.py
@@ -1,0 +1,79 @@
+"""TestState API tests for ready_event_to_icav2_wes_request_event_sfn_template.
+
+Validates JSONata expressions and Task state data flow for the state machine
+that converts a READY event into an ICAv2 WES request event.
+"""
+
+from __future__ import annotations
+
+import json
+
+import boto3
+import pytest
+
+from orcabus_pipeline_test_utils.sfn_teststate import TestStateClient, TestStateAssertion
+
+TEMPLATE_NAME = "ready_event_to_icav2_wes_request_event_sfn_template"
+
+# Capture SFN client at import time before moto overwrites credentials.
+_SFN_CLIENT = boto3.client("stepfunctions", region_name="ap-southeast-2")
+
+
+@pytest.fixture(scope="module")
+def sfn_client():
+    """TestState client with real AWS credentials."""
+    return TestStateClient(region_name="ap-southeast-2", client=_SFN_CLIENT)
+
+
+@pytest.mark.sfn_teststate
+class TestSaveInputs:
+    """Test the initial 'Save inputs' Pass state."""
+
+    def test_assigns_input_as_variable(self, sfn_client, load_template):
+        """Pass state should assign the full input as dragenWgtsDnaReadyEventDetail."""
+        definition = load_template(TEMPLATE_NAME)
+
+        result = sfn_client.test_state(
+            definition=definition,
+            input_data={
+                "portalRunId": "20250606test",
+                "workflowRunName": "umccr--automated--dragen-wgts-dna--4-4-4--20250606test",
+                "payload": {"data": {"inputs": {}, "engineParameters": {}, "tags": {}}},
+            },
+            state_name="Save inputs",
+        )
+
+        assertion = TestStateAssertion(result)
+        assert assertion.assert_succeeded().passed
+        assert assertion.assert_next_state("Add Ready Comment").passed
+
+
+@pytest.mark.sfn_teststate
+class TestAddReadyComment:
+    """Test the 'Add Ready Comment' Task state."""
+
+    def test_succeeds_with_mocked_lambda(self, sfn_client, load_template):
+        """Should invoke Lambda and route to conversion step."""
+        definition = load_template(TEMPLATE_NAME)
+
+        result = sfn_client.test_state(
+            definition=definition,
+            input_data={},
+            variables={
+                "dragenWgtsDnaReadyEventDetail": {
+                    "orcabusId": "wfr.TEST123",
+                    "portalRunId": "20250606test",
+                    "workflowRunName": "umccr--automated--dragen-wgts-dna--4-4-4--20250606test",
+                    "payload": {"data": {"inputs": {}, "engineParameters": {}, "tags": {}}},
+                },
+            },
+            state_name="Add Ready Comment",
+            mock_result={"Payload": {}, "StatusCode": 200},
+            field_validation_mode="NONE",
+        )
+
+        assertion = TestStateAssertion(result)
+        assert assertion.assert_succeeded().passed
+        assert assertion.assert_next_state(
+            "Convert Dragen WGTS DNA Ready Event to ICAv2 WES Event"
+        ).passed

--- a/app/step-functions-templates/tests/test_validate_draft_data_and_put_ready_event.py
+++ b/app/step-functions-templates/tests/test_validate_draft_data_and_put_ready_event.py
@@ -1,0 +1,159 @@
+"""TestState API tests for validate_draft_data_and_put_ready_event_sfn_template.
+
+Validates JSONata expressions, Choice branching, and Task state data flow
+for the validation + READY event emission state machine.
+"""
+
+from __future__ import annotations
+
+import json
+
+import boto3
+import pytest
+
+from orcabus_pipeline_test_utils.sfn_teststate import TestStateClient, TestStateAssertion
+
+TEMPLATE_NAME = "validate_draft_data_and_put_ready_event_sfn_template"
+
+# Capture SFN client at import time before moto overwrites credentials.
+_SFN_CLIENT = boto3.client("stepfunctions", region_name="ap-southeast-2")
+
+
+@pytest.fixture(scope="module")
+def sfn_client():
+    """TestState client with real AWS credentials."""
+    return TestStateClient(region_name="ap-southeast-2", client=_SFN_CLIENT)
+
+
+@pytest.mark.sfn_teststate
+class TestSaveEventVars:
+    """Test the initial Pass state variable assignment."""
+
+    def test_assigns_variables_from_input(self, sfn_client, load_template, load_scenario):
+        """Pass state should assign detail, workflowRunId, payload, payloadData."""
+        definition = load_template(TEMPLATE_NAME)
+        scenario = load_scenario(TEMPLATE_NAME, "happy_path")
+
+        result = sfn_client.test_state(
+            definition=definition,
+            input_data=scenario["input"],
+            state_name="Save Event Vars",
+            inspection_level="DEBUG",
+        )
+
+        assertion = TestStateAssertion(result)
+        assert assertion.assert_succeeded().passed
+        assert assertion.assert_next_state("Validate Draft Complete Event").passed
+
+
+@pytest.mark.sfn_teststate
+class TestIsDraftEventComplete:
+    """Test the 'Is Draft Event Complete?' Choice state branching."""
+
+    def test_valid_routes_to_post_schema_validation(self, sfn_client, load_template):
+        """When isValid=true, should route to 'Run post-schema validation'."""
+        definition = load_template(TEMPLATE_NAME)
+
+        result = sfn_client.test_state(
+            definition=definition,
+            input_data={"isValid": True},
+            state_name="Is Draft Event Complete?",
+        )
+
+        assertion = TestStateAssertion(result)
+        assert assertion.assert_succeeded().passed
+        assert assertion.assert_next_state("Run post-schema validation").passed
+
+    def test_invalid_routes_to_pass(self, sfn_client, load_template):
+        """When isValid=false, should exit via 'Pass' without emitting READY."""
+        definition = load_template(TEMPLATE_NAME)
+
+        result = sfn_client.test_state(
+            definition=definition,
+            input_data={"isValid": False},
+            state_name="Is Draft Event Complete?",
+        )
+
+        assertion = TestStateAssertion(result)
+        assert assertion.assert_succeeded().passed
+        assert assertion.assert_next_state("Pass").passed
+
+
+@pytest.mark.sfn_teststate
+class TestValidateDraftCompleteEvent:
+    """Test the validation Task state with mocked Lambda responses."""
+
+    def test_valid_schema_extracts_is_valid_true(self, sfn_client, load_template):
+        """Should extract isValid=true from mocked Lambda Payload."""
+        definition = load_template(TEMPLATE_NAME)
+
+        result = sfn_client.test_state(
+            definition=definition,
+            input_data={},
+            variables={
+                "payloadData": {"inputs": {}, "engineParameters": {}},
+                "workflowRunId": "wfr.ABCDEF123456",
+            },
+            state_name="Validate Draft Complete Event",
+            mock_result={"Payload": {"isValid": True}, "StatusCode": 200},
+            field_validation_mode="NONE",
+            inspection_level="DEBUG",
+        )
+
+        assertion = TestStateAssertion(result)
+        assert assertion.assert_succeeded().passed
+        assert assertion.assert_next_state("Is Draft Event Complete?").passed
+        assert assertion.assert_output({"isValid": True}).passed
+
+    def test_invalid_schema_extracts_is_valid_false(self, sfn_client, load_template):
+        """Should extract isValid=false from mocked Lambda Payload."""
+        definition = load_template(TEMPLATE_NAME)
+
+        result = sfn_client.test_state(
+            definition=definition,
+            input_data={},
+            variables={
+                "payloadData": {},
+                "workflowRunId": "wfr.ABCDEF123456",
+            },
+            state_name="Validate Draft Complete Event",
+            mock_result={"Payload": {"isValid": False}, "StatusCode": 200},
+            field_validation_mode="NONE",
+        )
+
+        assertion = TestStateAssertion(result)
+        assert assertion.assert_succeeded().passed
+        assert assertion.assert_output({"isValid": False}).passed
+
+
+@pytest.mark.sfn_teststate
+class TestWorkflowInputsAreValid:
+    """Test the 'Workflow Inputs are Valid' Choice state."""
+
+    def test_valid_inputs_route_to_push_ready_event(self, sfn_client, load_template):
+        """When isValid=true, should route to 'Push READY Event'."""
+        definition = load_template(TEMPLATE_NAME)
+
+        result = sfn_client.test_state(
+            definition=definition,
+            input_data={"isValid": True},
+            state_name="Workflow Inputs are Valid",
+        )
+
+        assertion = TestStateAssertion(result)
+        assert assertion.assert_succeeded().passed
+        assert assertion.assert_next_state("Push READY Event").passed
+
+    def test_invalid_inputs_route_to_pass(self, sfn_client, load_template):
+        """When isValid=false, should exit via 'Pass'."""
+        definition = load_template(TEMPLATE_NAME)
+
+        result = sfn_client.test_state(
+            definition=definition,
+            input_data={"isValid": False},
+            state_name="Workflow Inputs are Valid",
+        )
+
+        assertion = TestStateAssertion(result)
+        assert assertion.assert_succeeded().passed
+        assert assertion.assert_next_state("Pass").passed

--- a/app/tests/README.md
+++ b/app/tests/README.md
@@ -1,0 +1,337 @@
+# Python App Tests
+
+Shared test dependencies, configuration, and documentation for all Python tests in this service.
+
+## Directory Layout
+
+```
+app/
+├── tests/
+│   └── requirements-test.txt                # Shared Python test dependencies
+├── lambdas/
+│   └── tests/
+│       ├── __init__.py
+│       ├── conftest.py                      # Service-specific fixtures + shared plugin registration
+│       ├── test_*.py                        # One test file per Lambda function
+│       └── examples/                        # Example test templates for common patterns
+│           ├── test_data_transformation_example.py
+│           ├── test_api_call_example.py
+│           └── test_validation_example.py
+└── step-functions-templates/
+    └── tests/
+        ├── __init__.py
+        ├── conftest.py                      # SFN fixtures (TestState client, template loader, scenarios)
+        ├── test_asl_validation.py           # ASL structural validation tests
+        ├── test_teststate_integration.py    # TestState API integration tests (sfn_teststate marker)
+        ├── test_*.py                        # One test file per Step Function template
+        ├── mocks/                           # MockConfigFile.json per state machine
+        │   ├── populate_draft_data_sfn_template/
+        │   ├── validate_draft_data_and_put_ready_event_sfn_template/
+        │   ├── ready_event_to_icav2_wes_request_event_sfn_template/
+        │   └── icav2_wes_event_to_wrsc_event_sfn_template/
+        └── scenarios/                       # Input/output scenario definitions per SFN
+            ├── populate_draft_data_sfn_template/
+            ├── validate_draft_data_and_put_ready_event_sfn_template/
+            ├── ready_event_to_icav2_wes_request_event_sfn_template/
+            └── icav2_wes_event_to_wrsc_event_sfn_template/
+```
+
+## Prerequisites
+
+- Python 3.14+
+
+## Install Dependencies
+
+```bash
+pip install -r app/tests/requirements-test.txt
+```
+
+This installs:
+
+- `orcabus-pipeline-test-utils` — shared pytest plugin (fixtures + ASL validation + TestState API harness)
+- `pytest` — test runner
+- `moto` — AWS service mocking (S3, SSM, Secrets Manager, EventBridge, Lambda)
+- `boto3` — AWS SDK
+- `jsonschema` — JSON schema validation
+- `deepdiff` — deep payload comparison (used by `compare_payload` Lambda)
+
+## Running Tests
+
+```bash
+# All Python tests
+pytest
+
+# Verbose output with short tracebacks
+pytest -v --tb=short
+```
+
+### Lambda Unit Tests
+
+```bash
+pytest app/lambdas/tests/ -v --tb=short
+```
+
+### ASL Validation
+
+```bash
+pytest app/step-functions-templates/tests/test_asl_validation.py -v --tb=short
+```
+
+### Run by Marker
+
+```bash
+# Only Lambda unit tests
+pytest -m lambda_unit
+
+# Only ASL validation
+pytest -m asl_validation
+
+# Only TestState API integration tests
+pytest -m sfn_teststate
+
+# Exclude tests requiring AWS credentials
+pytest -m "not sfn_teststate"
+```
+
+## Markers
+
+| Marker | Description | Requires |
+|--------|-------------|----------|
+| `lambda_unit` | Lambda function unit tests | — |
+| `asl_validation` | ASL definition structural validation tests | — |
+| `sfn_teststate` | Step Functions TestState API integration tests | AWS credentials with `states:TestState` permission |
+
+Markers are enforced via `--strict-markers` in `pytest.ini`. Using an unregistered marker will cause an error.
+
+## Post-Deployment Smoke Tests
+
+Smoke tests are **not** part of the pytest suite. They are run as a standalone script during the CI/CD pipeline (CodeBuild step after deployment):
+
+```bash
+python3 smoke-tests/run-smoke-tests.py \
+    --role-arn arn:aws:iam::ACCOUNT_ID:role/OrcaBusBeta-SmokeTestRole \
+    --region ap-southeast-2
+```
+
+The smoke test runner discovers all deployed resources (Lambdas, state machines, SSM parameters) directly from the CloudFormation stacks and verifies:
+
+- Lambda DryRun invocations succeed
+- State machines are ACTIVE with no unresolved placeholders
+- State machine IAM roles have required permissions (lambda:InvokeFunction, events:PutEvents, ssm:GetParameter)
+- All SSM parameters referenced by state machines and Lambdas exist in the deployed stateful stack
+
+See `smoke-tests/run-smoke-tests.py` and `smoke-tests/smoke-test-config.json` for details.
+
+## TestState API Integration Tests
+
+The `sfn_teststate` tests use the [AWS TestState API](https://docs.aws.amazon.com/step-functions/latest/dg/test-state-isolation.html) to validate individual state logic (JSONata expressions, Choice branching, data flow) against the real Step Functions service.
+
+### How it works
+
+The TestState API executes a single state from your ASL definition and returns the output, next state transition, and optionally intermediate data (after InputPath, after Parameters, etc.). When you provide a `mock` parameter for Task states, the API uses your mocked response instead of calling the actual downstream service (Lambda, SSM, EventBridge, etc.).
+
+**Key point:** When a mock is provided, `roleArn` becomes optional — the service does not assume a role since no real downstream calls are made. This means you do not need any IAM role deployed, only AWS credentials that allow calling `states:TestState`.
+
+### What these tests validate
+
+- **Pass states:** Variable assignment via JSONata `Assign` expressions
+- **Choice states:** Condition evaluation and correct branch routing
+- **Task states:** Input/output processing (Arguments, Output extractors) with mocked service responses
+- **Data flow:** That JSONata expressions correctly transform data between states
+
+### Requirements
+
+- AWS credentials (any credentials that allow calling `stepfunctions:TestState`)
+- No IAM role ARN needed (mocks bypass downstream service calls)
+- No deployed resources needed (state definitions are sent inline to the API)
+
+### Running locally
+
+```bash
+# With AWS credentials configured (e.g. via AWS_PROFILE or env vars)
+pytest -m sfn_teststate -v --tb=short
+
+# Exclude from local runs (default workflow)
+pytest -m "not sfn_teststate"
+```
+
+### Example test
+
+```python
+@pytest.mark.sfn_teststate
+class TestChoiceBranching:
+    def test_valid_draft_routes_to_validation(self, sfn_client, load_template):
+        definition = load_template("validate_draft_data_and_put_ready_event_sfn_template")
+
+        result = sfn_client.test_state(
+            definition=definition,
+            input_data={"isValid": True},
+            state_name="Is Draft Event Complete?",
+        )
+
+        assertion = TestStateAssertion(result)
+        assert assertion.assert_succeeded().passed
+        assert assertion.assert_next_state("Run post-schema validation").passed
+```
+
+## Shared Fixtures
+
+The following fixtures are provided automatically by the `orcabus-pipeline-test-utils` pytest plugin. No import is needed — they are auto-registered.
+
+### `aws_mocks`
+
+Session-scoped fixture providing pre-configured mock AWS clients via moto. Provides mocked clients for S3, SSM Parameter Store, Secrets Manager, and EventBridge.
+
+```python
+def test_ssm_read(aws_mocks):
+    ssm_client = aws_mocks.ssm
+    ssm_client.put_parameter(Name="/test/param", Value="hello", Type="String")
+    response = ssm_client.get_parameter(Name="/test/param")
+    assert response["Parameter"]["Value"] == "hello"
+```
+
+### `lambda_context`
+
+Factory fixture returning a mock AWS Lambda context object with configurable attributes.
+
+```python
+def test_with_context(lambda_context):
+    ctx = lambda_context(
+        function_name="my-function",
+        memory_limit_in_mb=512,
+        aws_request_id="test-request-id"
+    )
+    assert ctx.function_name == "my-function"
+    assert ctx.memory_limit_in_mb == 512
+```
+
+### `event_builder`
+
+Factory fixture that wraps a dictionary payload into a Lambda event argument.
+
+```python
+def test_handler(event_builder, lambda_context):
+    event = event_builder({"sample_id": "SMP001", "library_id": "LIB001"})
+    ctx = lambda_context()
+    result = handler(event, ctx)
+    assert result["status"] == "success"
+```
+
+### SFN-Specific Fixtures (from `app/step-functions-templates/tests/conftest.py`)
+
+| Fixture | Scope | Description |
+|---------|-------|-------------|
+| `load_template` | function | Factory to load and resolve ASL templates by name |
+| `load_scenario` | function | Factory to load scenario JSON files by template and scenario name |
+| `load_mock_config` | function | Factory to load `MockConfigFile.json` by template name |
+| `teststate_client` | function | `TestStateClient` instance for TestState API tests |
+| `assert_state` | function | Factory to create `TestStateAssertion` from a `TestStateResult` |
+| `assert_path` | function | Factory to create `PathAssertion` from a list of `TestStateResult`s |
+
+## Service-Specific Fixtures
+
+The `app/lambdas/tests/conftest.py` provides service-specific constants:
+
+| Fixture | Value | Purpose |
+|---------|-------|---------|
+| `service_name` | `"dragen-wgts-dna"` | Workflow service identifier |
+| `event_source` | `"orcabus.dragenwgtsdna"` | EventBridge source |
+| `event_bus_name` | `"OrcaBusMain"` | EventBridge bus name |
+| `ssm_prefix` | `"/orcabus/workflows/dragen-wgts-dna/"` | SSM parameter prefix |
+
+## Adding New Test Cases
+
+### Adding a New Lambda Test
+
+1. Create a new Lambda directory at `app/lambdas/<function_name>_py/`
+2. Create a test file at `app/lambdas/tests/test_<function_name>.py`
+3. Use the shared fixtures (`event_builder`, `lambda_context`, `aws_mocks`) — they are auto-registered via the `orcabus-pipeline-test-utils` plugin
+4. If your Lambda uses a Lambda Layer dependency, mock it before importing the handler (see `examples/test_api_call_example.py`)
+
+Example test structure:
+
+```python
+"""Tests for <function_name> Lambda."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Path setup for Lambda handler import
+LAMBDA_DIR = Path(__file__).resolve().parents[1] / "<function_name>_py"
+sys.path.insert(0, str(LAMBDA_DIR))
+
+from <function_name> import handler  # noqa: E402
+
+
+class TestHappyPath:
+    def test_basic_invocation(self, event_builder, lambda_context):
+        event = event_builder({"key": "value"})
+        ctx = lambda_context(function_name="my-function")
+
+        result = handler(event, ctx)
+
+        assert result["status"] == "success"
+```
+
+If no corresponding `test_<function_name>.py` file exists for a Lambda module, pytest will emit a warning listing the untested functions (implemented in the root `conftest.py`).
+
+### Adding a New SFN Test Scenario
+
+1. Create a scenario JSON file at `app/step-functions-templates/tests/scenarios/<sfn_template_name>/<scenario_name>.json`:
+
+```json
+{
+  "scenario_name": "happy_path",
+  "description": "All steps complete successfully",
+  "state_machine_template": "<template_name>.asl.json",
+  "test_case_name": "HappyPath",
+  "input": { "...": "..." },
+  "expected_status": "SUCCEEDED",
+  "expected_output": { "...": "..." },
+  "expected_states_visited": ["State1", "State2"]
+}
+```
+
+2. Create or update the `MockConfigFile.json` at `app/step-functions-templates/tests/mocks/<sfn_template_name>/MockConfigFile.json` with mocked responses for the new scenario:
+
+```json
+{
+  "StateMachines": {
+    "<state_machine_name>": {
+      "TestCases": {
+        "<TestCaseName>": {
+          "<TaskStateName>": "<MockedResponseName>"
+        }
+      }
+    }
+  },
+  "MockedResponses": {
+    "<MockedResponseName>": {
+      "0": {
+        "Return": { "key": "value" }
+      }
+    }
+  }
+}
+```
+
+3. Write a test function in `app/step-functions-templates/tests/test_<sfn_template_name>.py` that uses the `load_scenario`, `load_template`, and `sfn_client` fixtures from `conftest.py`.
+
+## CI Integration
+
+### Pull Request Workflow (GitHub Actions)
+
+Lambda unit tests and ASL validation run during PRs via the `pr-tests.yml` workflow in a dedicated `test-app` job that runs in parallel to `test-iac`. The job is conditional on `check-changes` detecting relevant file modifications. The `ci-gate` job requires both `test-iac` and `test-app` to pass before a PR can merge.
+
+### Deployment Pipeline (CodePipeline)
+
+The full test suite runs in the `unitAppTestConfig` stage of the `DeploymentStackPipeline` before deployment to Beta. This stage has AWS credentials available, so TestState API tests also run:
+
+```bash
+python3.14 -m pip install -r app/tests/requirements-test.txt --quiet
+python3.14 -m pytest app/lambdas/tests/ -v --tb=short
+python3.14 -m pytest app/step-functions-templates/tests/test_asl_validation.py -v --tb=short
+python3.14 -m pytest app/step-functions-templates/tests/test_teststate_integration.py -v --tb=short
+```

--- a/app/tests/requirements-test.txt
+++ b/app/tests/requirements-test.txt
@@ -1,0 +1,6 @@
+orcabus-pipeline-test-utils @ git+https://github.com/OrcaBus/platform-cdk-constructs.git@test/add-pipeline-tests#subdirectory=packages/orcabus-pipeline-test-utils
+pytest>=7.4.0,<9.0.0
+moto[s3,ssm,secretsmanager,events,lambda]>=5.0.0,<6.0.0
+boto3>=1.34.0
+jsonschema>=4.20.0,<5.0.0
+deepdiff>=6.0.0,<8.0.0

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,55 @@
+"""
+Root conftest.py for pytest configuration.
+
+Implements untested Lambda detection: compares app/lambdas/ directories
+(ending in _py) against test files in app/lambdas/tests/ and emits a
+warning listing Lambda functions without corresponding test files.
+"""
+
+from pathlib import Path
+
+import pytest
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Detect Lambda modules without corresponding test files and emit warnings."""
+    root_dir = Path(config.rootdir)
+    lambdas_dir = root_dir / "app" / "lambdas"
+    tests_dir = lambdas_dir / "tests"
+
+    if not lambdas_dir.is_dir():
+        return
+
+    # Find all Lambda module directories (ending in _py, excluding tests/ and __pycache__/)
+    lambda_modules: list[str] = []
+    excluded_dirs = {"tests", "__pycache__"}
+    for entry in sorted(lambdas_dir.iterdir()):
+        if (
+            entry.is_dir()
+            and entry.name.endswith("_py")
+            and entry.name not in excluded_dirs
+        ):
+            lambda_modules.append(entry.name)
+
+    if not lambda_modules:
+        return
+
+    # Determine which Lambda modules have corresponding test files
+    # Convention: directory `foo_bar_py` -> test file `test_foo_bar.py`
+    untested_modules: list[str] = []
+    for module_dir_name in lambda_modules:
+        # Strip the _py suffix to get the module name
+        module_name = module_dir_name.removesuffix("_py")
+        expected_test_file = tests_dir / f"test_{module_name}.py"
+        if not expected_test_file.is_file():
+            untested_modules.append(module_dir_name)
+
+    if untested_modules:
+        modules_list = "\n  - ".join(untested_modules)
+        config.issue_config_time_warning(
+            pytest.PytestWarning(
+                f"Lambda functions without test files:\n  - {modules_list}\n"
+                f"Expected test files in: {tests_dir.relative_to(root_dir)}/"
+            ),
+            stacklevel=1,
+        )

--- a/infrastructure/toolchain/stateless-stack.ts
+++ b/infrastructure/toolchain/stateless-stack.ts
@@ -11,7 +11,14 @@ export class StatelessStack extends cdk.Stack {
 
     new DeploymentStackPipeline(this, 'StatelessDragenWgtsDnaPipeline', {
       unitAppTestConfig: {
-        command: [],
+        command: [
+          // Install Python test dependencies
+          'python3.14 -m pip install -r app/tests/requirements-test.txt --quiet',
+          // Run Lambda unit tests
+          'python3.14 -m pytest app/lambdas/tests/ -v --tb=short',
+          // Run ASL validation
+          'python3.14 -m pytest app/step-functions-templates/tests/test_asl_validation.py -v --tb=short',
+        ],
       },
       githubBranch: 'main',
       githubRepo: REPO_NAME,

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,10 @@
+[pytest]
+testpaths = app/lambdas/tests app/step-functions-templates/tests
+python_files = test_*.py
+python_classes = Test*
+python_functions = test_*
+markers =
+    lambda_unit: Lambda function unit tests
+    asl_validation: ASL definition validation tests
+    sfn_teststate: Step Functions TestState API integration tests (requires AWS credentials)
+addopts = --strict-markers -v

--- a/test/toolchain.test.ts
+++ b/test/toolchain.test.ts
@@ -10,7 +10,7 @@ describe('cdk-nag-stateless-toolchain-stack', () => {
 
   const statelessStack = new StatelessStack(app, 'StatelessStack', {
     env: {
-      account: '123456789',
+      account: '123456789012',
       region: 'ap-southeast-2',
     },
   });
@@ -65,7 +65,7 @@ describe('cdk-nag-stateful-toolchain-stack', () => {
 
   const statefulStack = new StatefulStack(app, 'StatefulStack', {
     env: {
-      account: '123456789',
+      account: '123456789012',
       region: 'ap-southeast-2',
     },
   });


### PR DESCRIPTION
- Add Python unit tests for all Lambda functions in app/lambdas/tests/
- Add ASL validation and scenario tests for Step Functions templates
- Add shared pytest configuration (pytest.ini, root conftest.py)
- Add test dependencies in app/tests/requirements-test.txt
- Add test-app and test-app-all Makefile targets
- Update CI workflow with test-app job for PR checks
- Configure unitAppTestConfig in CodePipeline with Python test commands
- Fix test account IDs to valid 12-digit format
- Add README-tests.md documenting the testing framework