### PR TITLE
fix: guard get_s3_key_prefix_by_project_id against ApiException and None

### DIFF
--- a/app/lambdas/post_schema_validation_py/post_schema_validation.py
+++ b/app/lambdas/post_schema_validation_py/post_schema_validation.py
@@ -333,7 +333,41 @@ def handler(event, context) -> Dict[str, bool]:
     tags = payload_data.get("tags", {})
 
     # Get the project prefix
-    project_prefix = cast(str, get_s3_key_prefix_by_project_id(engine_parameters.get("projectId")))
+    project_id = engine_parameters.get("projectId")
+    if project_id is None:
+        add_comment_to_workflow_run(
+            workflow_run_orcabus_id=workflow_run_id,
+            comment=_format_comment_with_arn(
+                "Post schema validation failed: projectId is not set",
+                execution_arn
+            ),
+            author=COMMENT_AUTHOR
+        )
+        return {"isValid": False}
+
+    try:
+        project_prefix = get_s3_key_prefix_by_project_id(project_id)
+    except ApiException:
+        add_comment_to_workflow_run(
+            workflow_run_orcabus_id=workflow_run_id,
+            comment=_format_comment_with_arn(
+                f"Post schema validation failed: cannot resolve S3 key prefix for projectId '{project_id}'",
+                execution_arn
+            ),
+            author=COMMENT_AUTHOR
+        )
+        return {"isValid": False}
+
+    if project_prefix is None:
+        add_comment_to_workflow_run(
+            workflow_run_orcabus_id=workflow_run_id,
+            comment=_format_comment_with_arn(
+                f"Post schema validation failed: no S3 key prefix configured for projectId '{project_id}'",
+                execution_arn
+            ),
+            author=COMMENT_AUTHOR
+        )
+        return {"isValid": False}
 
     # Confirm the engine parameters match
     is_valid, comment = validate_engine_parameters(
@@ -351,9 +385,8 @@ def handler(event, context) -> Dict[str, bool]:
         # Validate the inputs
         is_valid, comment = validate_inputs(
             inputs,
-            project_id=engine_parameters.get("projectId"),
-            # Get the key prefix for the project
-            project_prefix=cast(str, get_s3_key_prefix_by_project_id(engine_parameters.get("projectId")))
+            project_id=project_id,
+            project_prefix=project_prefix
         )
 
     # Check if this is a clinical sample and if we


### PR DESCRIPTION
## Summary

Adds defensive handling around `get_s3_key_prefix_by_project_id` in the `post_schema_validation` lambda.

The wrapica function can:
1. **Raise `ApiException`** — if the ICAv2 API call fails (network issues, auth problems, invalid project)
2. **Return `None`** — if the project has no storage configuration

Previously neither failure mode was handled — the lambda would crash with an uncontrolled exception. Now we:
- Validate `projectId` is set before calling
- Catch `ApiException`
- Check for `None` return
- Write a descriptive comment to the workflow run record
- Return `{"isValid": false}` gracefully
- Removed redundant second call to `get_s3_key_prefix_by_project_id` in the `validate_inputs` call — reuses the already-resolved `project_prefix` variable

## Related PRs

This fix is being applied consistently across all pipeline manager services:
- OrcaBus/service-arriba-wgts-rna-pipeline-manager
- OrcaBus/service-bclconvert-interop-qc-pipeline-manager
- OrcaBus/service-dragen-tso500-ctdna-pipeline-manager
- OrcaBus/service-dragen-wgts-dna-pipeline-manager
- OrcaBus/service-dragen-wgts-rna-pipeline-manager
- OrcaBus/service-oncoanalyser-wgts-dna-pipeline-manager
- OrcaBus/service-oncoanalyser-wgts-rna-pipeline-manager
- OrcaBus/service-sash-pipeline-manager