### PR TITLE
chore: upgrade @orcabus/platform-cdk-constructs to 1.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@aws-cdk/aws-lambda-python-alpha": "2.262.1-alpha.0",
-    "@orcabus/platform-cdk-constructs": "1.7.0",
+    "@orcabus/platform-cdk-constructs": "1.7.2",
     "aws-cdk-lib": "^2.263.0",
     "constructs": "^10.7.2"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: 2.262.1-alpha.0
         version: 2.262.1-alpha.0(aws-cdk-lib@2.263.0(constructs@10.7.2))(constructs@10.7.2)
       '@orcabus/platform-cdk-constructs':
-        specifier: 1.7.0
-        version: 1.7.0(@aws-cdk/aws-lambda-python-alpha@2.262.1-alpha.0(aws-cdk-lib@2.263.0(constructs@10.7.2))(constructs@10.7.2))(aws-cdk-lib@2.263.0(constructs@10.7.2))(constructs@10.7.2)
+        specifier: 1.7.2
+        version: 1.7.2(@aws-cdk/aws-lambda-python-alpha@2.262.1-alpha.0(aws-cdk-lib@2.263.0(constructs@10.7.2))(constructs@10.7.2))(aws-cdk-lib@2.263.0(constructs@10.7.2))(constructs@10.7.2)
       aws-cdk-lib:
         specifier: ^2.263.0
         version: 2.263.0(constructs@10.7.2)
@@ -443,8 +443,8 @@ packages:
       '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.3
       '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.3
 
-  '@orcabus/platform-cdk-constructs@1.7.0':
-    resolution: {integrity: sha512-OJ573BwIHRnGMoXcggu3ipje2mvihZcbFMfXMI9ZA7CeEpHvpc21l45PV/rS/V0znQec4puaLW8ZM25s+HY0XQ==}
+  '@orcabus/platform-cdk-constructs@1.7.2':
+    resolution: {integrity: sha512-oayS7Cpe94ZrwLIzKgDuHC1uOeN8r88CpgJDo3NIOyLp4wVCgAtTFPA+GL/mAL43PICLC++rfQcUFcgbx60IhQ==}
     peerDependencies:
       '@aws-cdk/aws-lambda-python-alpha': ^2.244.0-alpha.0
       aws-cdk-lib: ^2.244.0
@@ -2337,7 +2337,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@orcabus/platform-cdk-constructs@1.7.0(@aws-cdk/aws-lambda-python-alpha@2.262.1-alpha.0(aws-cdk-lib@2.263.0(constructs@10.7.2))(constructs@10.7.2))(aws-cdk-lib@2.263.0(constructs@10.7.2))(constructs@10.7.2)':
+  '@orcabus/platform-cdk-constructs@1.7.2(@aws-cdk/aws-lambda-python-alpha@2.262.1-alpha.0(aws-cdk-lib@2.263.0(constructs@10.7.2))(constructs@10.7.2))(aws-cdk-lib@2.263.0(constructs@10.7.2))(constructs@10.7.2)':
     dependencies:
       '@aws-cdk/aws-lambda-python-alpha': 2.262.1-alpha.0(aws-cdk-lib@2.263.0(constructs@10.7.2))(constructs@10.7.2)
       aws-cdk-lib: 2.263.0(constructs@10.7.2)


### PR DESCRIPTION
Upgrade `@orcabus/platform-cdk-constructs` from `1.7.0` to `1.7.2`.